### PR TITLE
add requirements specification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests
+openai
+cohere
+transformers
+torch>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
 # TODO: what is find_packages
 # TODO: what is the right format for 'keywords'
-# TODO: how do you add the right packages? What is 'packages' vs 'install_requires'? How to format it properly?
 
 from setuptools import setup, find_packages
 
-VERSION = '0.0.1'
+VERSION = "0.0.1"
 
-DESCRIPTION = 'Wrappers for common large langugae models (LLMs) with support for evaluation.'
+DESCRIPTION = "Wrappers for common large langugae models (LLMs) with support for evaluation."
 
-LONG_DESCRIPTION = 'PhaseLLM provides wrappers for common large language models and use cases. This makes it easy to swap models in and out as needed. We also provide support for evaluation of models so you can choose which models are better to use.'
+LONG_DESCRIPTION = "PhaseLLM provides wrappers for common large language models and use cases. This makes it easy to swap models in and out as needed. We also provide support for evaluation of models so you can choose which models are better to use."
 
 setup(
     name="phasellm",
@@ -17,14 +16,23 @@ setup(
     long_description=LONG_DESCRIPTION,
     author="Wojciech Gryc",
     author_email="hello@phaseai.com",
-    license='MIT',
+    license="MIT",
     packages=find_packages(),
-    install_requires=[],
-    keywords='llm, nlp, evaluation, ai',
-    classifiers= [
+    install_requires=[
+        "requests",
+        # TODO: make model packages optional installs?
+        # TODO: specify min versions
+        "openai",
+        "cohere",
+        "transformers",
+        "torch",
+    ],
+    python_requires=">=3.7",
+    keywords="llm, nlp, evaluation, ai",
+    classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
-        'License :: OSI Approved :: MIT License',
+        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-    ]
+    ],
 )


### PR DESCRIPTION
Hope a PR is alright here - noticed that requirements weren't specified here and a TODO for it.

There is a (brief) discussion of `install_requires` vs requirements files here: https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/

TLDR, `install_requires` will install the indicated packages/versions when someone does `pip install phasellm`. Conventions are pretty loose and information is often duplicated between the two; `requirements.txt` or `requirements_dev.txt` often lists development requirements and uses more specific version pins/ranges.

TODOs:
- [ ] update package version 
- [ ] release to pypi
- [ ] specify min/max versions of packages if important (torch was the only requirement that seemed important to have a min version)