### PR TITLE
Feature/webpage agent

### DIFF
--- a/phasellm/agents.py
+++ b/phasellm/agents.py
@@ -636,7 +636,7 @@ class WebpageAgent(Agent):
         return f"WebpageAgent(name={self.name})"
 
     @staticmethod
-    def _validate(url: str):
+    def _validate_url(url: str) -> None:
         """
         This method validates that a url can be used by the agent.
         Returns:
@@ -645,8 +645,7 @@ class WebpageAgent(Agent):
         if not url.startswith('http'):
             raise ValueError(f"Url must use HTTP(S). Invalid URL: {url}")
 
-        if url.endswith('.pdf'):
-            raise ValueError(f"WebpageAgent cannot process PDFs. Invalid URL: {url}")
+        # TODO consider adding more validations.
 
     @staticmethod
     def _handle_errors(res: requests.Response) -> None:
@@ -742,7 +741,7 @@ class WebpageAgent(Agent):
             A string containing the html of the webpage.
 
         """
-        # Ensure chromium is installed.
+        # Ensure chromium is installed for the headless browser.
         subprocess.call('playwright install chromium')
 
         with sync_playwright() as p:
@@ -783,7 +782,7 @@ class WebpageAgent(Agent):
             A string containing the text of the webpage.
         """
 
-        self._validate(url=url)
+        self._validate_url(url=url)
 
         if use_javascript:
             data = self._scrape_html_and_js(url=url, wait_for_selector=wait_for_selector)
@@ -791,8 +790,6 @@ class WebpageAgent(Agent):
             data = self._scrape_html(url=url, headers=headers)
 
         if text_only:
-            data = self._parse_html(
-                html=data
-            )
+            data = self._parse_html(html=data)
 
         return data

--- a/phasellm/agents.py
+++ b/phasellm/agents.py
@@ -662,18 +662,29 @@ class WebpageAgent(Agent):
                             f"{res.reason}")
 
     @staticmethod
-    def _parse_html(html: str) -> str:
+    def _parse_html(html: str, text_only: bool = True, body_only: bool = False) -> str:
         """
         This method parses the given html string.
         Args:
             html: The html to parse.
+            text_only: If True, only the text of the webpage is returned. If False, the entire HTML is returned.
+            body_only: If True, only the body of the webpage is returned. If False, the entire HTML is returned.
 
         Returns:
             The string containing the webpage text or html.
 
         """
-        soup = BeautifulSoup(html, features='lxml')
-        return soup.get_text()
+        if text_only or body_only:
+            soup = BeautifulSoup(html, features='lxml')
+            if text_only and body_only:
+                text = soup.body.get_text()
+            elif text_only:
+                text = soup.get_text()
+            else:
+                text = str(soup.body)
+        else:
+            text = html
+        return text.strip()
 
     @staticmethod
     def _prep_headers(headers: Dict = None) -> Dict:
@@ -764,7 +775,8 @@ class WebpageAgent(Agent):
             headers: Dict = None,
             use_javascript: bool = False,
             wait_for_selector: str = None,
-            text_only: bool = False
+            text_only: bool = True,
+            body_only: bool = True
     ) -> str:
         """
         This method scrapes a webpage and returns a string containing the text of the webpage.
@@ -777,6 +789,7 @@ class WebpageAgent(Agent):
             should be on the page but it is not there yet since it needs to be rendered by javascript. Only used if
             use_javascript is True.
             text_only: If True, only the text of the webpage is returned. If False, the entire HTML is returned.
+            body_only: If True, only the body of the webpage is returned. If False, the entire HTML is returned.
 
         Returns:
             A string containing the text of the webpage.
@@ -789,7 +802,6 @@ class WebpageAgent(Agent):
         else:
             data = self._scrape_html(url=url, headers=headers)
 
-        if text_only:
-            data = self._parse_html(html=data)
+        data = self._parse_html(html=data, text_only=text_only, body_only=body_only)
 
         return data

--- a/phasellm/agents.py
+++ b/phasellm/agents.py
@@ -774,21 +774,21 @@ class WebpageAgent(Agent):
             self,
             url: str,
             headers: Dict = None,
-            use_javascript: bool = False,
+            use_browser: bool = False,
             wait_for_selector: str = None,
             text_only: bool = True,
             body_only: bool = True
     ) -> str:
         """
-        This method scrapes a webpage and returns a string containing the text of the webpage.
+        This method scrapes a webpage and returns a string containing the html or text of the webpage.
         Args:
             url: The URL of the webpage to scrape.
             headers: A dictionary of headers to use for the request.
-            use_javascript: If True, the webpage is rendered using a headless browser, allowing javascript to run and
+            use_browser: If True, the webpage is rendered using a headless browser, allowing javascript to run and
             hydrate the page. If False, the webpage is scraped as-is.
             wait_for_selector: The selector to wait for before returning the HTML. Useful for when you know something
             should be on the page but it is not there yet since it needs to be rendered by javascript. Only used if
-            use_javascript is True.
+            use_browser is True.
             text_only: If True, only the text of the webpage is returned. If False, the entire HTML is returned.
             body_only: If True, only the body of the webpage is returned. If False, the entire HTML is returned.
 
@@ -800,7 +800,7 @@ class WebpageAgent(Agent):
 
         headers = self._prep_headers(headers=headers)
 
-        if use_javascript:
+        if use_browser:
             data = self._scrape_html_and_js(url=url, headers=headers, wait_for_selector=wait_for_selector)
         else:
             data = self._scrape_html(url=url, headers=headers)

--- a/phasellm/agents.py
+++ b/phasellm/agents.py
@@ -628,6 +628,38 @@ class NewsSummaryAgent(Agent):
 class WebpageAgent(Agent):
 
     def __init__(self, name: str = ''):
+        """
+        Create a WebpageAgent.
+
+        This agent helps you scrape webpages.
+
+        Examples:
+            >>> from phasellm.agents import WebpageAgent
+            Use default parameters:
+                >>> agent = WebpageAgent()
+                >>> text = agent.scrape('https://10millionsteps.com/ai-inflection')
+            Keep html tags:
+                >>> agent = WebpageAgent()
+                >>> text = agent.scrape('https://10millionsteps.com/ai-inflection', text_only=False, body_only=False)
+            Keep html tags, but only return body content:
+                >>> agent = WebpageAgent()
+                >>> text = agent.scrape('https://10millionsteps.com/ai-inflection', text_only=False, body_only=True)
+            Use a headless browser to enable scraping of dynamic content:
+                >>> agent = WebpageAgent()
+                >>> text = agent.scrape('https://10millionsteps.com/ai-inflection', text_only=False, body_only=True,
+                ...                     use_browser=True)
+            Pass custom headers:
+                >>> agent = WebpageAgent()
+                >>> headers = {'Example': 'header'}
+                >>> text = agent.scrape('https://10millionsteps.com/ai-inflection', headers=headers)
+            Wait for a selector to load (useful for dynamic content, only works when use_browser=True):
+                >>> agent = WebpageAgent()
+                >>> text = agent.scrape('https://10millionsteps.com/ai-inflection', use_browser=True,
+                ...                     wait_for_selector='#dynamic')
+
+        Args:
+            name: The name of the agent (optional)
+        """
         super().__init__(name=name)
 
         self.session = requests.Session()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ sseclient-py>=1.7.2
 docker>=6.1.3
 pandas>=2.0.0
 openpyxl>=3.1.0
+beautifulsoup4>=4.12.2
+lxml>=4.9.2
+fake-useragent>=1.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ openpyxl>=3.1.0
 beautifulsoup4>=4.12.2
 lxml>=4.9.2
 fake-useragent>=1.1.3
+playwright>=1.35.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,11 @@ setup(
         "typing-extensions>=4.6.3",
         "urllib3==1.26.6",
         "sseclient-py>=1.7.2",
-        "docker>=6.1.3"
+        "docker>=6.1.3",
+        "beautifulsoup4>=4.12.2",
+        "lxml>=4.9.2",
+        "fake-useragent>=1.1.3",
+        "playwright>=1.35.0"
     ],
     python_requires=">=3.8.0",
     keywords="llm, nlp, evaluation, ai",

--- a/tests/e2e/agents/test_e2e_agents.py
+++ b/tests/e2e/agents/test_e2e_agents.py
@@ -184,7 +184,7 @@ class TestE2EWebpageAgent(TestCase):
             url='https://www.cbc.ca/news/canada/google-facebook-canadian-news-1.6894029',
             text_only=True,
             body_only=False,
-            use_javascript=False
+            use_browser=False
         )
         self.assertTrue(
             'Canadian journalism.Government says' in
@@ -196,7 +196,7 @@ class TestE2EWebpageAgent(TestCase):
             url='https://www.cbc.ca/news/canada/google-facebook-canadian-news-1.6894029',
             text_only=False,
             body_only=False,
-            use_javascript=False
+            use_browser=False
         )
         self.assertTrue(
             '<title data-rh="true">When will Canadian news disappear from Google, Facebook? What the Bill C-18 rift '
@@ -209,7 +209,7 @@ class TestE2EWebpageAgent(TestCase):
             url='https://github.com/facebook/react',
             text_only=False,
             body_only=False,
-            use_javascript=True
+            use_browser=True
         )
         self.assertTrue(
             'Go to file\n</a>'
@@ -221,7 +221,7 @@ class TestE2EWebpageAgent(TestCase):
             url='https://github.com/facebook/react',
             text_only=True,
             body_only=False,
-            use_javascript=True
+            use_browser=True
         )
         self.assertTrue(
             'Go to file'
@@ -233,7 +233,7 @@ class TestE2EWebpageAgent(TestCase):
             url='https://www.w3schools.com/xml/note.xml',
             text_only=True,
             body_only=False,
-            use_javascript=False
+            use_browser=False
         )
         self.assertTrue(
             'Tove'
@@ -245,7 +245,7 @@ class TestE2EWebpageAgent(TestCase):
             url='https://www.w3schools.com/xml/note.xml',
             text_only=False,
             body_only=False,
-            use_javascript=False
+            use_browser=False
         )
         self.assertTrue(
             '<to>Tove</to>'
@@ -259,7 +259,7 @@ class TestE2EWebpageAgent(TestCase):
                 url='https://arxiv.org/pdf/2306.17759.pdf',
                 text_only=True,
                 body_only=False,
-                use_javascript=False
+                use_browser=False
             )
         except ValueError:
             exception = True
@@ -276,7 +276,7 @@ class TestE2EWebpageAgent(TestCase):
                 url=url,
                 text_only=True,
                 body_only=False,
-                use_javascript=False
+                use_browser=False
             )
             self.assertTrue(
                 len(text) > 0,
@@ -288,7 +288,7 @@ class TestE2EWebpageAgent(TestCase):
             url='https://10millionsteps.com/ai-inflection',
             text_only=True,
             body_only=True,
-            use_javascript=False
+            use_browser=False
         )
         self.assertTrue(
             'There are two broad types of risks we need to consider in this AI-enabled future.\n'
@@ -301,7 +301,7 @@ class TestE2EWebpageAgent(TestCase):
             url='https://10millionsteps.com/ai-inflection',
             text_only=False,
             body_only=True,
-            use_javascript=False
+            use_browser=False
         )
         self.assertTrue(
             '<p>There are two broad types of risks we need to consider in this AI-enabled future.</p>\n'

--- a/tests/e2e/agents/test_e2e_agents.py
+++ b/tests/e2e/agents/test_e2e_agents.py
@@ -182,17 +182,21 @@ class TestE2EWebpageAgent(TestCase):
     def test_scrape_single_html_text(self):
         text = self.fixture.scrape(
             url='https://www.cbc.ca/news/canada/google-facebook-canadian-news-1.6894029',
-            text_only=True
+            text_only=True,
+            body_only=False,
+            use_javascript=False
         )
         self.assertTrue(
-            'Government says law will apply to companies with' in
+            'Canadian journalism.Government says' in
             text, f"Text does not contain expected string.\n{text}"
         )
 
     def test_scrape_single_html(self):
         text = self.fixture.scrape(
             url='https://www.cbc.ca/news/canada/google-facebook-canadian-news-1.6894029',
-            text_only=False
+            text_only=False,
+            body_only=False,
+            use_javascript=False
         )
         self.assertTrue(
             '<title data-rh="true">When will Canadian news disappear from Google, Facebook? What the Bill C-18 rift '
@@ -204,6 +208,7 @@ class TestE2EWebpageAgent(TestCase):
         text = self.fixture.scrape(
             url='https://github.com/facebook/react',
             text_only=False,
+            body_only=False,
             use_javascript=True
         )
         self.assertTrue(
@@ -215,6 +220,7 @@ class TestE2EWebpageAgent(TestCase):
         text = self.fixture.scrape(
             url='https://github.com/facebook/react',
             text_only=True,
+            body_only=False,
             use_javascript=True
         )
         self.assertTrue(
@@ -225,7 +231,9 @@ class TestE2EWebpageAgent(TestCase):
     def test_scrape_single_xml_text(self):
         text = self.fixture.scrape(
             url='https://www.w3schools.com/xml/note.xml',
-            text_only=True
+            text_only=True,
+            body_only=False,
+            use_javascript=False
         )
         self.assertTrue(
             'Tove'
@@ -235,7 +243,9 @@ class TestE2EWebpageAgent(TestCase):
     def test_scrape_single_xml(self):
         text = self.fixture.scrape(
             url='https://www.w3schools.com/xml/note.xml',
-            text_only=False
+            text_only=False,
+            body_only=False,
+            use_javascript=False
         )
         self.assertTrue(
             '<to>Tove</to>'
@@ -247,7 +257,9 @@ class TestE2EWebpageAgent(TestCase):
         try:
             self.fixture.scrape(
                 url='https://arxiv.org/pdf/2306.17759.pdf',
-                text_only=True
+                text_only=True,
+                body_only=False,
+                use_javascript=False
             )
         except ValueError:
             exception = True
@@ -260,8 +272,39 @@ class TestE2EWebpageAgent(TestCase):
             'https://arxiv.org/abs/2306.17759'
         ]
         for url in urls:
-            text = self.fixture.scrape(url=url, text_only=True)
+            text = self.fixture.scrape(
+                url=url,
+                text_only=True,
+                body_only=False,
+                use_javascript=False
+            )
             self.assertTrue(
                 len(text) > 0,
                 f"Text is empty.\n{text}"
             )
+
+    def test_scrape_single_html_text_only_body_only(self):
+        text = self.fixture.scrape(
+            url='https://10millionsteps.com/ai-inflection',
+            text_only=True,
+            body_only=True,
+            use_javascript=False
+        )
+        self.assertTrue(
+            'There are two broad types of risks we need to consider in this AI-enabled future.\n'
+            'Extrinsic risks' in text,
+            f"Text does not contain expected string.\n{text}"
+        )
+
+    def test_scrape_single_html_only_body(self):
+        text = self.fixture.scrape(
+            url='https://10millionsteps.com/ai-inflection',
+            text_only=False,
+            body_only=True,
+            use_javascript=False
+        )
+        self.assertTrue(
+            '<p>There are two broad types of risks we need to consider in this AI-enabled future.</p>\n'
+            '<p><em>Extrinsic risks' in text,
+            f"Text does not contain expected string.\n{text}"
+        )

--- a/tests/e2e/agents/test_e2e_agents.py
+++ b/tests/e2e/agents/test_e2e_agents.py
@@ -1,12 +1,13 @@
 import os
-import shutil
 import time
+import shutil
+import random
+
+import docker.errors
 
 from pathlib import Path
 
 from unittest import TestCase
-
-import docker.errors
 
 from phasellm.exceptions import LLMCodeException
 
@@ -176,55 +177,68 @@ class TestE2EWebpageAgent(TestCase):
 
     def setUp(self):
         self.fixture = WebpageAgent()
+        time.sleep(random.random())
 
     def test_scrape_single_html_text(self):
         text = self.fixture.scrape(
-            url='https://www.sec.gov/Archives/edgar/data/1045810/000122520823007007/0001225208-23-007007-index.htm',
+            url='https://www.cbc.ca/news/canada/google-facebook-canadian-news-1.6894029',
             text_only=True
         )
         self.assertTrue(
-            'NVIDIA CORP' in
+            'Government says law will apply to companies with' in
             text, f"Text does not contain expected string.\n{text}"
         )
 
     def test_scrape_single_html(self):
         text = self.fixture.scrape(
-            url='https://www.sec.gov/Archives/edgar/data/320193/000119312514383437/d783162d10k.htm',
+            url='https://www.cbc.ca/news/canada/google-facebook-canadian-news-1.6894029',
             text_only=False
         )
         self.assertTrue(
-            'APPLE INC.'
+            '<title data-rh="true">When will Canadian news disappear from Google, Facebook? What the Bill C-18 rift '
+            'means for you | CBC News</title>'
             in text, f"Text does not contain expected string.\n{text}"
         )
 
     def test_scrape_single_html_javascript(self):
         text = self.fixture.scrape(
-            url='https://www.sec.gov/ix?doc=/Archives/edgar/data/1318605/000095017023013890/tsla-20230331.htm',
-            text_only=False
+            url='https://github.com/facebook/react',
+            text_only=False,
+            use_javascript=True
         )
-        print(text)
         self.assertTrue(
-            'Tesla'
+            'Go to file\n</a>'
+            in text, f"Text does not contain expected string.\n{text}"
+        )
+
+    def test_scrape_single_html_text_javascript(self):
+        text = self.fixture.scrape(
+            url='https://github.com/facebook/react',
+            text_only=True,
+            use_javascript=True
+        )
+        self.assertTrue(
+            'Go to file'
             in text, f"Text does not contain expected string.\n{text}"
         )
 
     def test_scrape_single_xml_text(self):
         text = self.fixture.scrape(
-            url='https://www.sec.gov/Archives/edgar/data/1045810/000122520823007007/doc4.xml',
+            url='https://www.w3schools.com/xml/note.xml',
             text_only=True
         )
         self.assertTrue(
-            'NVIDIA CORP'
+            'Tove'
             in text, f"Text does not contain expected string.\n{text}"
         )
 
     def test_scrape_single_xml(self):
         text = self.fixture.scrape(
-            url='https://www.sec.gov/Archives/edgar/data/320193/000032019318000145/aapl-20180929.xml',
+            url='https://www.w3schools.com/xml/note.xml',
             text_only=False
         )
         self.assertTrue(
-            '<xbrli:identifier scheme="http://www.sec.gov/CIK">0000320193</xbrli:identifier>'
+            '<to>Tove</to>'
             in text, f"Text does not contain expected string.\n{text}"
         )
 

--- a/tests/unit/agents/test_agents.py
+++ b/tests/unit/agents/test_agents.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 
 from unittest.mock import patch
 
-from phasellm.agents import CodeExecutionAgent, SandboxedCodeExecutionAgent, EmailSenderAgent, NewsSummaryAgent
+from phasellm.agents import CodeExecutionAgent, SandboxedCodeExecutionAgent, EmailSenderAgent, NewsSummaryAgent, \
+    WebpageAgent
 
 
 class TestCodeExecutionAgent(TestCase):
@@ -173,3 +174,100 @@ class TestNewsSummaryAgent(TestCase):
     def test_get_query(self):
         # TODO consider mocking networking calls and making assertions on string output.
         pass
+
+# if text_only or body_only:
+#     soup = BeautifulSoup(html, features='lxml')
+#     if text_only and body_only:
+#         text = soup.body.get_text()
+#     elif text_only:
+#         text = soup.get_text()
+#     else:
+#         text = str(soup.body)
+# else:
+#     text = html
+# return text.strip()
+
+
+class TestWebpageAgent(TestCase):
+    test_html_str = (
+        "<html>"
+        "<head>"
+        "<meta charset=\"utf-8\">"
+        "<script src=\"https://test.com\"></script>"
+        "<link rel=\"stylesheet\" href=\"https://test.com\">"
+        "<style> body { background-color: #000000; } </style>"
+        "<title>Test</title>"
+        "</head>"
+        "<body>"
+        "<p>Hello, world!</p>"
+        "</body>"
+        "</html>"
+    )
+
+    def setUp(self) -> None:
+        self.fixture = WebpageAgent()
+
+    def test_parse_html(self):
+        actual = self.fixture._parse_html(
+            html=self.test_html_str,
+            text_only=False,
+            body_only=False
+        )
+        expected = self.test_html_str
+        self.assertEqual(actual, expected)
+
+    def test_parse_html_text_only(self):
+        actual = self.fixture._parse_html(
+            html=self.test_html_str,
+            text_only=True,
+            body_only=False
+        )
+        expected = "TestHello, world!"
+        self.assertEqual(actual, expected)
+
+    def test_parse_html_body_only(self):
+        actual = self.fixture._parse_html(
+            html=self.test_html_str,
+            text_only=False,
+            body_only=True
+        )
+        expected = "<body><p>Hello, world!</p></body>"
+        self.assertEqual(actual, expected)
+
+    def test_parse_html_text_only_body_only(self):
+        actual = self.fixture._parse_html(
+            html=self.test_html_str,
+            text_only=True,
+            body_only=True
+        )
+        expected = "Hello, world!"
+        self.assertEqual(actual, expected)
+
+    def test_prep_headers(self):
+        actual = self.fixture._prep_headers(
+            headers={
+                'test': 'test'
+            }
+        )
+        expected = {
+            'test': 'test',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            # 'User-Agent': UserAgent().chrome, // This is here for reference only. It is added by _prep_headers.
+            'Referrer': 'https://www.google.com/',
+            'Accept-Language': 'en-US,en;q=0.5',
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Connection': 'keep-alive',
+            'Upgrade-Insecure-Requests': '1',
+            'Cache-Control': 'max-age=0'
+        }
+        self.assertEqual(actual['test'], expected['test'])
+        self.assertEqual(actual['Accept'], expected['Accept'])
+        self.assertEqual(actual['Referrer'], expected['Referrer'])
+        self.assertEqual(actual['Accept-Language'], expected['Accept-Language'])
+        self.assertEqual(actual['Accept-Encoding'], expected['Accept-Encoding'])
+        self.assertEqual(actual['Connection'], expected['Connection'])
+        self.assertEqual(actual['Upgrade-Insecure-Requests'], expected['Upgrade-Insecure-Requests'])
+        self.assertEqual(actual['Cache-Control'], expected['Cache-Control'])
+
+        self.assertTrue('User-Agent' in actual)
+        self.assertTrue('Chrome' in actual['User-Agent'])

--- a/tests/unit/agents/test_agents.py
+++ b/tests/unit/agents/test_agents.py
@@ -175,18 +175,6 @@ class TestNewsSummaryAgent(TestCase):
         # TODO consider mocking networking calls and making assertions on string output.
         pass
 
-# if text_only or body_only:
-#     soup = BeautifulSoup(html, features='lxml')
-#     if text_only and body_only:
-#         text = soup.body.get_text()
-#     elif text_only:
-#         text = soup.get_text()
-#     else:
-#         text = str(soup.body)
-# else:
-#     text = html
-# return text.strip()
-
 
 class TestWebpageAgent(TestCase):
     test_html_str = (


### PR DESCRIPTION
### WebpageAgent

**Summary of Changes**

This PR adds a new agent `WebpageAgent`. The agent allows users to scrape a web page for its content. It is capable of scraping javascript rendered content with a headless browser.

Example:
```
webpage_agent = WebpageAgent()
data = webpage_agent.scrape('https://10millionsteps.com/ai-inflection')
```

Parameters:
- `url`
    - The url of the webpage to scrape.
- `headers`
    - Optionally pass a dictionary of headers to use for the request.
- `use_browser`
    - If True, the webpage is rendered using a headless browser, allowing javascript to run and hydrate the page. If False, the webpage is scraped as-is.
- `wait_for_selector`
    - The selector to wait for before returning the HTML. Useful for when you know something should be on the page but it is not there yet since it needs to be rendered by javascript. Only used if use_browser is True.
- `text_only`
    - If True, only the text of the webpage is returned. If False, the entire HTML is returned.
- `body_only`
    - If True, only the body of the webpage is returned. If False, the entire HTML is returned. 

E2E and unit tests were added.