### PR TITLE
Task/setup options

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,6 @@ setup(
         "requests>=2.24.0",
         "openai>=0.26.0",
         "cohere>=4.0.0",
-        "transformers>=4.25.0",
-        "accelerate>=0.16.0",
-        "torch>=1.0.0",
         "python-dotenv",
         "pandas>=2.0.0",
         "openpyxl>=3.1.0",
@@ -37,6 +34,13 @@ setup(
         "fake-useragent>=1.1.3",
         "playwright>=1.35.0"
     ],
+    extras_require={
+        "complete": [
+            "transformers>=4.25.0",
+            "accelerate>=0.16.0",
+            "torch>=1.0.0",
+        ]
+    },
     python_requires=">=3.8.0",
     keywords="llm, nlp, evaluation, ai",
     classifiers=[


### PR DESCRIPTION
Split out transformers, accelerate, and torch requirements into 'complete' extras. To install these dependencies, users will now need to:

```
pip install phasellm[complete]
```