### PR TITLE
Claude 2 + WebpageAgent Robustness

### DIFF
--- a/demos-and-products/web-search-chatbot/demo.py
+++ b/demos-and-products/web-search-chatbot/demo.py
@@ -7,7 +7,7 @@ from phasellm.agents import WebSearchAgent
 from flask import Flask, request, render_template, jsonify
 
 load_dotenv()
-llm = ClaudeWrapper(os.getenv("ANTHROPIC_API_KEY"))
+llm = ClaudeWrapper(os.getenv("ANTHROPIC_API_KEY"), model='claude-2')
 web_search_agent = WebSearchAgent(
     api_key=os.getenv("GOOGLE_SEARCH_API_KEY")
 )

--- a/phasellm/agents.py
+++ b/phasellm/agents.py
@@ -741,6 +741,8 @@ class WebpageAgent(Agent):
             headers['Referrer'] = 'https://www.google.com/'
         if 'Accept-Encoding' not in headers:
             headers['Accept-Encoding'] = 'gzip, deflate, br'
+        if 'Accept-Language' not in headers:
+            headers['Accept-Language'] = '*'
         if 'Connection' not in headers:
             headers['Connection'] = 'keep-alive'
         if 'Upgrade-Insecure-Requests' not in headers:
@@ -766,7 +768,7 @@ class WebpageAgent(Agent):
         self._handle_errors(res=res)
 
         try:
-            return res.content.decode('utf-8')
+            return res.content.decode(res.encoding)
         except Exception as e:
             raise Exception(f"WebpageAgent could not decode the response from the URL: {url}\n{e}")
 

--- a/phasellm/types.py
+++ b/phasellm/types.py
@@ -1,0 +1,10 @@
+from typing import Union, Literal
+
+CLAUDE_MODEL = Union[
+    str,
+    Literal["claude-v1"],
+    Literal["claude-instant-1"],
+    Literal["claude-instant-1.1"],
+    Literal["claude-2"],
+    Literal["claude-2.0"],
+]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "0.0.13"
+VERSION = "0.0.15"
 
 DESCRIPTION = "Wrappers for common large language models (LLMs) with support for evaluation."
 

--- a/tests/e2e/llms/test_e2e_llms.py
+++ b/tests/e2e/llms/test_e2e_llms.py
@@ -507,8 +507,14 @@ class E2ETestChatBot(TestCase):
 
         test_chatbot_resend(self, fixture)
 
-    def test_claude_chat(self):
-        llm = ClaudeWrapper(anthropic_api_key, model="claude-v1")
+    def test_claude_chat_2023_01_01(self):
+        llm = ClaudeWrapper(anthropic_api_key, model="claude-v1", anthropic_version="2023-01-01")
+        fixture = ChatBot(llm)
+
+        test_chatbot_chat(self, fixture)
+
+    def test_claude_chat_2023_06_01(self):
+        llm = ClaudeWrapper(anthropic_api_key, model="claude-v1", anthropic_version="2023-06-01")
         fixture = ChatBot(llm)
 
         test_chatbot_chat(self, fixture)
@@ -643,8 +649,14 @@ class E2ETestStreamingChatBot(TestCase):
 
     # TODO Consider adding test_openai_gpt_streaming_resend_sse()
 
-    def test_claude_streaming_chat(self):
-        llm = StreamingClaudeWrapper(anthropic_api_key, model="claude-v1")
+    def test_claude_streaming_chat_2023_01_01(self):
+        llm = StreamingClaudeWrapper(anthropic_api_key, model="claude-v1", anthropic_version="2023-01-01")
+        fixture = ChatBot(llm)
+
+        test_streaming_chatbot_chat(self, fixture=fixture, chunk_time_seconds_threshold=0.5, verbose=False)
+
+    def test_claude_streaming_chat_2023_06_01(self):
+        llm = StreamingClaudeWrapper(anthropic_api_key, model="claude-v1", anthropic_version="2023-06-01")
         fixture = ChatBot(llm)
 
         test_streaming_chatbot_chat(self, fixture=fixture, chunk_time_seconds_threshold=0.5, verbose=False)

--- a/tests/unit/agents/test_agents.py
+++ b/tests/unit/agents/test_agents.py
@@ -242,7 +242,7 @@ class TestWebpageAgent(TestCase):
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             # 'User-Agent': UserAgent().chrome, // This is here for reference only. It is added by _prep_headers.
             'Referrer': 'https://www.google.com/',
-            'Accept-Language': 'en-US,en;q=0.5',
+            'Accept-Language': '*',
             'Accept-Encoding': 'gzip, deflate, br',
             'Connection': 'keep-alive',
             'Upgrade-Insecure-Requests': '1',


### PR DESCRIPTION
**Summary of Changes**

* Update claude wrappers to facilitate new API spec.
* Change claude wrapper default model to claude-2.
* Add new types.py file to keep track of custom types.
* Improve robustness of WebpageAgent.
* Update web search chatbot demo to use claude-2.
* Bump version to 0.0.15