### PR TITLE
Refactors for OpenAI azure endpoints. New api_config parameter was in…

### DIFF
--- a/phasellm/configurations.py
+++ b/phasellm/configurations.py
@@ -1,0 +1,200 @@
+import openai
+
+from importlib import reload
+
+from abc import ABC, abstractmethod
+
+from azure.identity import DefaultAzureCredential
+
+
+class APIConfiguration(ABC):
+
+    def __init__(self, model: str = 'gpt-3.5-turbo'):
+        self.model = model
+
+    @abstractmethod
+    def __call__(self):
+        """
+        Abstract method to initialize the API configuration.
+
+        Returns:
+
+        """
+        pass
+
+    @abstractmethod
+    def get_base_api_kwargs(self):
+        """
+        Abstract method for the base API kwargs for the API configuration.
+
+        Returns:
+
+        """
+        pass
+
+
+class OpenAIConfiguration(APIConfiguration):
+    name = 'openai'
+
+    def __init__(
+            self,
+            api_key: str,
+            organization: str = None,
+            model: str = 'gpt-3.5-turbo'
+    ):
+        """
+        Initializes the OpenAI API configuration.
+
+        Args:
+            api_key: The OpenAI API key.
+            organization: The OpenAI organization.
+            model: The model to use.
+
+        """
+        super().__init__(model=model)
+
+        self.api_key = api_key
+        self.organization = organization
+
+    def __call__(self):
+        """
+        Calls the OpenAI API configuration to initialize the OpenAI API.
+
+        Returns:
+
+        """
+        # Reset the OpenAI API configuration.
+        reload(openai)
+
+        # Set the OpenAI API configuration.
+        openai.api_key = self.api_key
+        openai.organization = self.organization
+
+    def get_base_api_kwargs(self):
+        """
+        Returns the base API kwargs for the OpenAI API configuration.
+
+        Returns:
+            A Dict of the base API kwargs for the OpenAI API configuration.
+
+        """
+        return {
+            'model': self.model
+        }
+
+
+class AzureAPIConfiguration(APIConfiguration):
+    name = 'azure'
+
+    def __init__(
+            self,
+            api_key: str,
+            api_base: str,
+            api_version: str = '2023-05-15',
+            deployment_id: str = 'gpt-3.5-turbo'
+    ):
+        """
+        Initializes the Azure API configuration.
+
+        Args:
+            api_key: The Azure API key.
+            api_base: The Azure API base.
+            api_version: The Azure API version.
+            deployment_id: The model deployment ID.
+
+        """
+        super().__init__(model=deployment_id)
+
+        self.api_key = api_key
+        self.api_base = api_base
+        self.api_version = api_version
+
+        self.deployment_id = deployment_id
+
+    def __call__(self):
+        """
+        Calls the Azure API configuration to initialize the Azure API.
+
+        Returns:
+
+        """
+        # Reset the OpenAI API configuration.
+        reload(openai)
+
+        # Set the OpenAI API configuration.
+        openai.api_key = self.api_key
+        openai.api_type = self.name
+        openai.api_base = self.api_base
+        openai.api_version = self.api_version
+
+    def get_base_api_kwargs(self):
+        """
+        Returns the base API kwargs for the Azure API configuration.
+
+        Returns:
+            A Dict of the base API kwargs for the Azure API configuration.
+
+        """
+        return {
+            'deployment_id': self.deployment_id
+        }
+
+
+class AzureActiveDirectoryConfiguration:
+    name = 'azure_ad'
+
+    def __init__(
+            self,
+            api_base: str,
+            api_version: str = '2023-05-15',
+            deployment_id: str = 'gpt-3.5-turbo'
+    ):
+        """
+        Initializes the Azure Active Directory API configuration.
+
+        Learn more:
+        https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/switching-endpoints#azure-active-directory-authentication
+
+        Args:
+            api_base: The Azure Active Directory API base.
+            api_version: The API version. https://learn.microsoft.com/en-us/azure/ai-services/openai/reference
+            deployment_id: The model deployment ID
+
+        """
+        super().__init__(model=deployment_id)
+
+        self.api_base = api_base
+        self.api_version = api_version
+
+        self.deployment_id = deployment_id
+
+    def __call__(self):
+        """
+        Calls the Azure Active Directory API configuration to initialize the Azure Active Directory API.
+
+        Returns:
+
+        """
+        # Reset the OpenAI API configuration.
+        reload(openai)
+
+        # Set the OpenAI API configuration.
+        credential = DefaultAzureCredential()
+        token = credential.get_token('https://cognitiveservices.azure.com/.default')
+
+        openai.api_type = self.name
+        openai.api_key = token.token
+        openai.api_base = self.api_base
+        openai.api_version = self.api_version
+
+    def get_base_api_kwargs(self):
+        """
+        Returns the base API kwargs for the Azure Active Directory API configuration.
+
+        Returns:
+            A Dict containing the base API kwargs for the Azure Active Directory API configuration.
+
+        """
+        return {
+            'deployment_id': self.deployment_id
+        }

--- a/phasellm/types.py
+++ b/phasellm/types.py
@@ -1,4 +1,6 @@
-from typing import Union, Literal
+from phasellm.configurations import OpenAIConfiguration, AzureAPIConfiguration, AzureActiveDirectoryConfiguration
+
+from typing import Union, Literal, Optional
 
 CLAUDE_MODEL = Union[
     str,
@@ -7,4 +9,10 @@ CLAUDE_MODEL = Union[
     Literal["claude-instant-1.1"],
     Literal["claude-2"],
     Literal["claude-2.0"],
+]
+
+OPENAI_API_CONFIG = Union[
+    OpenAIConfiguration,
+    AzureAPIConfiguration,
+    AzureActiveDirectoryConfiguration
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ lxml>=4.9.2
 fake-useragent>=1.1.3
 playwright>=1.35.0
 feedparser>=6.0.10
+azure-identity>=1.14.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         "lxml>=4.9.2",
         "fake-useragent>=1.1.3",
         "playwright>=1.35.0",
-        "feedparser>=6.0.10"
+        "feedparser>=6.0.10",
+        "azure-identity>=1.14.0"
     ],
     extras_require={
         "complete": [

--- a/tests/e2e/llms/test_e2e_llms.py
+++ b/tests/e2e/llms/test_e2e_llms.py
@@ -5,6 +5,8 @@ from unittest import TestCase
 
 from dotenv import load_dotenv
 
+from phasellm.configurations import AzureAPIConfiguration
+
 from phasellm.llms import \
     HuggingFaceInferenceWrapper, \
     BloomWrapper, \
@@ -27,6 +29,7 @@ from tests.e2e.llms.utils import test_streaming_chatbot_chat, test_streaming_cha
     test_streaming_chatbot_resend
 
 load_dotenv()
+azure_api_key = os.getenv("AZURE_API_KEY")
 openai_api_key = os.getenv("OPENAI_API_KEY")
 cohere_api_key = os.getenv("COHERE_API_KEY")
 anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
@@ -97,6 +100,15 @@ class E2ETestOpenAIGPTWrapper(TestCase):
 
     def test_complete_chat(self):
         fixture = OpenAIGPTWrapper(openai_api_key, model="gpt-3.5-turbo")
+        test_complete_chat(self, fixture, verbose=False)
+
+    def test_complete_chat_azure(self):
+        fixture = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
+            api_key=azure_api_key,
+            api_base='https://val-gpt4.openai.azure.com/',
+            api_version='2023-05-15',
+            deployment_id='gpt-4'
+        ))
         test_complete_chat(self, fixture, verbose=False)
 
     def test_complete_chat_kwargs(self):
@@ -257,6 +269,19 @@ class E2ETestStreamingOpenAIGPTWrapper(TestCase):
         Tests that the StreamingOpenAIGPTWrapper can be used to perform chat completion.
         """
         fixture = StreamingOpenAIGPTWrapper(openai_api_key, model="gpt-3.5-turbo")
+
+        test_streaming_complete_chat(self, fixture, verbose=False)
+
+    def test_complete_chat_azure(self):
+        """
+        Tests that the StreamingOpenAIGPTWrapper with azure configuration can be used to perform chat completion.
+        """
+        fixture = StreamingOpenAIGPTWrapper(api_config=AzureAPIConfiguration(
+            api_key=azure_api_key,
+            api_base='https://val-gpt4.openai.azure.com/',
+            api_version='2023-05-15',
+            deployment_id='gpt-4'
+        ))
 
         test_streaming_complete_chat(self, fixture, verbose=False)
 
@@ -501,6 +526,17 @@ class E2ETestChatBot(TestCase):
 
         test_chatbot_chat(self, fixture)
 
+    def test_openai_gpt_chat_azure(self):
+        llm = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
+            api_key=azure_api_key,
+            api_base='https://val-gpt4.openai.azure.com/',
+            api_version='2023-05-15',
+            deployment_id='gpt-4'
+        ))
+        fixture = ChatBot(llm)
+
+        test_chatbot_chat(self, fixture)
+
     def test_openai_gpt_resend(self):
         llm = OpenAIGPTWrapper(openai_api_key, model="gpt-3.5-turbo")
         fixture = ChatBot(llm)
@@ -631,6 +667,17 @@ class E2ETestStreamingChatBot(TestCase):
 
     def test_openai_gpt_streaming_chat(self):
         llm = StreamingOpenAIGPTWrapper(openai_api_key, model="gpt-3.5-turbo")
+        fixture = ChatBot(llm)
+
+        test_streaming_chatbot_chat(self, fixture=fixture, chunk_time_seconds_threshold=0.5, verbose=False)
+
+    def test_openai_gpt_streaming_chat_azure(self):
+        llm = StreamingOpenAIGPTWrapper(api_config=AzureAPIConfiguration(
+            api_key=azure_api_key,
+            api_base='https://val-gpt4.openai.azure.com/',
+            api_version='2023-05-15',
+            deployment_id='gpt-4'
+        ))
         fixture = ChatBot(llm)
 
         test_streaming_chatbot_chat(self, fixture=fixture, chunk_time_seconds_threshold=0.5, verbose=False)


### PR DESCRIPTION
**Summary of Changes**

Refactors for OpenAI azure endpoints.

            >>> from phasellm.llms import OpenAIGPTWrapper

            Use OpenAI's API:
                >>> llm = OpenAIGPTWrapper(apikey="my-api-key", model="gpt-3.5-turbo")
                >>> llm.text_completion(prompt="Hello, my name is")
                "Hello, my name is ChatGPT."

            Use OpenAI's API with api_config:
                >>> from phasellm.configurations import OpenAIConfiguration
                >>> llm = OpenAIGPTWrapper(api_config=OpenAIConfiguration(
                ...     apikey="my-api-key",
                ...     organization="my-org",
                ...     model="gpt-3.5-turbo"
                ... ))

            Use Azure's API:
                >>> from phasellm.configurations import AzureAPIConfiguration
                >>> llm = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
                ...     apikey="azure_api_key",
                ...     api_base='https://{your-resource-name}.openai.azure.com/',
                ...     api_version='2023-05-15',
                ...     deployment_id='gpt-4'
                ... ))
                >>> llm.text_completion(prompt="Hello, my name is")
                "Hello, my name is ChatGPT."

            Use Azure's API with Active Directory authentication:
                >>> from phasellm.configurations import AzureActiveDirectoryConfiguration
                >>> llm = OpenAIGPTWrapper(api_config=AzureActiveDirectoryConfiguration(
                ...     api_base='https://{your-resource-name}.openai.azure.com/',
                ...     api_version='2023-05-15',
                ...     deployment_id='gpt-4'
                ... ))
                >>> llm.text_completion(prompt="Hello, my name is")
                "Hello, my name is ChatGPT."

- New api_config parameter was introduced to both the StreamingOpenAIGPTWrapper and OpenAIGPTWrapper classes. These hold the configuration data for the API. Existing apikey and model parameters are subsumed by the api_config object. api_config takes precedence.

- Added tests