### PR TITLE
Update Docs References + Minor Docstring Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Large language model evaluation and workflow framework from [Phase AI](https://p
 
 - [Follow us on Twitter](https://twitter.com/phasellm) for updates.
 - [Star us on GitHub](https://github.com/wgryc/phasellm).
-- [Read the Docs](https://phasellm.com/docs/) -- currently limited to the module reference. Tutorials and code examples are below.
+- [Read the Docs](https://phasellm.readthedocs.io/en/latest/autoapi/phasellm/index.html) -- Module reference. Tutorials and code examples are below.
 
 ## Installation
 

--- a/phasellm/llms.py
+++ b/phasellm/llms.py
@@ -617,12 +617,12 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
     def __init__(
             self,
             apikey: Optional[str] = None,
-            api_config: Optional[OPENAI_API_CONFIG] = None,
             model: str = "gpt-3.5-turbo",
             format_sse: bool = False,
             append_stop_token: bool = True,
             stop_token: str = STOP_TOKEN,
             temperature: float = None,
+            api_config: Optional[OPENAI_API_CONFIG] = None,
             **kwargs: Any
     ):
         """
@@ -671,12 +671,12 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
 
         Args:
             apikey: The API key to access the OpenAI API.
-            api_config: The API configuration to use. Defaults to None. Takes precedence over apikey and model.
             model: The model to use. Defaults to "gpt-3.5-turbo".
             format_sse: Whether to format the SSE response from OpenAI. Defaults to False.
             append_stop_token: Whether to append the stop token to the end of the prompt. Defaults to True.
             stop_token: The stop token to use. Defaults to <|END|>.
             temperature: The temperature to use for the language model.
+            api_config: The API configuration to use. Defaults to None. Takes precedence over apikey and model.
             **kwargs: Keyword arguments to pass to the OpenAI API.
 
         """
@@ -695,6 +695,9 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
             self.api_config = OpenAIConfiguration(api_key=apikey, model=model)
         if api_config:
             self.api_config = api_config
+
+        if not hasattr(self, 'api_config'):
+            raise Exception('Must pass apikey or api_config. If using kwargs, check capitalization.')
 
         # Activate the configuration
         self.api_config()
@@ -801,9 +804,9 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
     def __init__(
             self,
             apikey: Optional[str] = None,
-            api_config: Optional[OPENAI_API_CONFIG] = None,
             model: str = "gpt-3.5-turbo",
             temperature: float = None,
+            api_config: Optional[OPENAI_API_CONFIG] = None,
             **kwargs: Any
     ):
         """
@@ -852,9 +855,9 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
 
         Args:
             apikey: The API key to access the OpenAI API.
-            api_config: The API configuration to use. Defaults to None. Takes precedence over apikey and model.
             model: The model to use. Defaults to "gpt-3.5-turbo".
             temperature: The temperature to use for the language model.
+            api_config: The API configuration to use. Defaults to None. Takes precedence over apikey and model.
             **kwargs: Keyword arguments to pass to the OpenAI API.
 
         """
@@ -867,6 +870,9 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
             self.api_config = OpenAIConfiguration(api_key=apikey, model=model)
         if api_config:
             self.api_config = api_config
+
+        if not hasattr(self, 'api_config'):
+            raise Exception('Must pass apikey or api_config. If using kwargs, check capitalization.')
 
         # Activate the configuration
         self.api_config()

--- a/phasellm/llms.py
+++ b/phasellm/llms.py
@@ -654,7 +654,7 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
                 ...     apikey="azure_api_key",
                 ...     api_base='https://{your-resource-name}.openai.azure.com/',
                 ...     api_version='2023-05-15',
-                ...     deployment_id='gpt-4'
+                ...     deployment_id='your-deployment-id'
                 ... ))
                 >>> llm.text_completion(prompt="Hello, my name is")
                 "Hello, my name is ChatGPT."
@@ -664,7 +664,7 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
                 >>> llm = StreamingOpenAIGPTWrapper(api_config=AzureActiveDirectoryConfiguration(
                 ...     api_base='https://{your-resource-name}.openai.azure.com/',
                 ...     api_version='2023-05-15',
-                ...     deployment_id='gpt-4'
+                ...     deployment_id='your-deployment-id'
                 ... ))
                 >>> llm.text_completion(prompt="Hello, my name is")
                 "Hello, my name is ChatGPT."
@@ -835,7 +835,7 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
                 ...     apikey="azure_api_key",
                 ...     api_base='https://{your-resource-name}.openai.azure.com/',
                 ...     api_version='2023-05-15',
-                ...     deployment_id='gpt-4'
+                ...     deployment_id='your-deployment-id'
                 ... ))
                 >>> llm.text_completion(prompt="Hello, my name is")
                 "Hello, my name is ChatGPT."
@@ -845,7 +845,7 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
                 >>> llm = OpenAIGPTWrapper(api_config=AzureActiveDirectoryConfiguration(
                 ...     api_base='https://{your-resource-name}.openai.azure.com/',
                 ...     api_version='2023-05-15',
-                ...     deployment_id='gpt-4'
+                ...     deployment_id='your-deployment-id'
                 ... ))
                 >>> llm.text_completion(prompt="Hello, my name is")
                 "Hello, my name is ChatGPT."

--- a/release_checklist.md
+++ b/release_checklist.md
@@ -7,5 +7,4 @@ This checklist is used prior to a new release, to ensure everything works proper
 - [ ] Publish final version to PyPI
 - [ ] Publish release in GitHub
 - [ ] Tweet about it
-- [ ] Update *Change Log* on site
-- [ ] Update docs at https://phasellm.com/docs 
+- [ ] Update *Change Log* on site 

--- a/tests/unit/llms/test_llms.py
+++ b/tests/unit/llms/test_llms.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from phasellm.llms import Prompt
+from phasellm.llms import Prompt, OpenAIGPTWrapper, StreamingOpenAIGPTWrapper
 
 
 class TestPrompt(TestCase):
@@ -14,3 +14,25 @@ class TestPrompt(TestCase):
         expected = "1: one, 2: two, 3: three"
 
         self.assertEqual(actual, expected, f"{actual} != {expected}")
+
+
+class TestOpenAIGPTWrapper(TestCase):
+    CONFIG_ERROR = 'Must pass apikey or api_config. If using kwargs, check capitalization.'
+
+    def test_config_error_incorrect_kwarg(self):
+        error = False
+        try:
+            self.fixture = OpenAIGPTWrapper(apiKey='test')
+        except Exception as e:
+            self.assertEqual(e.__str__(), self.CONFIG_ERROR)
+            error = True
+        self.assertTrue(error, 'Expected error to occur.')
+
+    def test_config_error_missing_config(self):
+        error = False
+        try:
+            self.fixture = OpenAIGPTWrapper()
+        except Exception as e:
+            self.assertEqual(e.__str__(), self.CONFIG_ERROR)
+            error = True
+        self.assertTrue(error, 'Expected error to occur.')


### PR DESCRIPTION
### Remove Old Docs References

**Summary of Changes**

- Changed doc link in `README.md` to point to ReadTheDocs.
- Removed doc update step from release checklist since they're now automatically generated on every merge to `dev` or `main`.

### Docstring Tweaks

- Minor tweak to docstrings for clarity.