### PR TITLE
Non-deterministic Tests

### DIFF
--- a/project_metadata.py
+++ b/project_metadata.py
@@ -2,7 +2,7 @@ NAME = "phasellm"
 
 AUTHOR = "Wojciech Gryc"
 
-VERSION = "0.0.16"
+VERSION = "0.0.17"
 
 DESCRIPTION = "Wrappers for common large language models (LLMs) with support for evaluation."
 

--- a/tests-non-deterministic/README.md
+++ b/tests-non-deterministic/README.md
@@ -1,0 +1,9 @@
+### Non Deterministic Tests
+
+These tests are non-deterministic in nature, so they should only be run and reviewed by a human.
+
+**Do not include these tests in an automated CI pipeline, or you may experience transient 
+failures**
+
+Note: we may be able to integrate these into CI if we set them up with retries and acceptable
+success rate thresholds.

--- a/tests-non-deterministic/llms/test_llms.py
+++ b/tests-non-deterministic/llms/test_llms.py
@@ -1,0 +1,40 @@
+import os
+
+from unittest import TestCase
+
+from dotenv import load_dotenv
+
+from phasellm.llms import OpenAIGPTWrapper, ChatBot
+
+load_dotenv()
+openai_api_key = os.getenv("OPENAI_API_KEY")
+
+
+class TestChatBot(TestCase):
+
+    def test_openai_gpt_chat_temperature(self):
+        prompt = 'What is the capital of Jupiter?'
+        verbose = True
+
+        # Test low temperature
+        llm = OpenAIGPTWrapper(openai_api_key, "gpt-3.5-turbo", temperature=0)
+        fixture = ChatBot(llm)
+        low_temp_res = fixture.chat(prompt)
+
+        # Test high temperature
+        llm = OpenAIGPTWrapper(openai_api_key, "gpt-3.5-turbo", temperature=2)
+        fixture = ChatBot(llm)
+        high_temp_res = fixture.chat(prompt)
+
+        if verbose:
+            print(f'Low temp response:\n{low_temp_res}')
+            print(f'Low temperature len: {len(low_temp_res)}')
+
+            print(f'High temp response:\n{high_temp_res}')
+            print(f'High temperature len: {len(high_temp_res)}')
+
+        # Responses should differ.
+        self.assertNotEqual(low_temp_res, high_temp_res)
+
+        # High temperature should generally produce longer responses.
+        self.assertTrue(len(low_temp_res) < len(high_temp_res))


### PR DESCRIPTION
### Non-deterministic Tests

**Summary of Changes**

Added new non deterministic tests folder, which includes temperature end-to-end tests which are non-deterministic in nature. Note that due to OpenAI's model implementation, `temperature=0` inferences are still non-deterministic (they sometimes yield a different answer, given enough prompts)