### PR TITLE
Implement beta version of new OpenAI Python client (v1). Add new last…

### DIFF
--- a/phasellm/configurations.py
+++ b/phasellm/configurations.py
@@ -95,7 +95,7 @@ class AzureAPIConfiguration(APIConfiguration):
             self,
             api_key: str,
             base_url: str = None,
-            api_version: str = '2023-08-01-preview',
+            api_version: str = '2023-05-15',
             deployment_id: str = 'gpt-3.5-turbo',
             response_callback: callable = lambda response: None,
             api_base: str = None
@@ -189,13 +189,12 @@ class AzureActiveDirectoryConfiguration:
 
         if api_base:
             warn('The api_base argument is deprecated. Use base_url instead.', DeprecationWarning)
-        if api_version:
-            warn('The api_version argument is deprecated and has no effect.', DeprecationWarning)
 
         self.base_url = base_url
         if api_base:
             self.base_url = api_base
 
+        self.api_version = api_version
         self.deployment_id = deployment_id
 
         self._response_callback = response_callback
@@ -217,6 +216,9 @@ class AzureActiveDirectoryConfiguration:
             api_key=token.token,
             base_url=self.base_url,
             http_client=httpx.Client(event_hooks={'response': [self._response_callback]}),
+            default_query={
+                'api-version': self.api_version
+            }
         )
 
     def get_base_api_kwargs(self):

--- a/phasellm/configurations.py
+++ b/phasellm/configurations.py
@@ -44,8 +44,7 @@ class OpenAIConfiguration(APIConfiguration):
             self,
             api_key: str,
             organization: str = None,
-            model: str = 'gpt-3.5-turbo',
-            response_callback: callable = lambda response: None
+            model: str = 'gpt-3.5-turbo'
     ):
         """
         Initializes the OpenAI API configuration.
@@ -54,7 +53,6 @@ class OpenAIConfiguration(APIConfiguration):
             api_key: The OpenAI API key.
             organization: The OpenAI organization.
             model: The model to use.
-            response_callback: A callback which is called when a response is received from the OpenAI API.
 
         """
         super().__init__(model=model)
@@ -62,7 +60,7 @@ class OpenAIConfiguration(APIConfiguration):
         self.api_key = api_key
         self.organization = organization
 
-        self._response_callback = response_callback
+        self.response_callback = lambda response: None
 
     def __call__(self):
         """
@@ -72,7 +70,7 @@ class OpenAIConfiguration(APIConfiguration):
 
         """
         self.client = OpenAI(
-            http_client=httpx.Client(event_hooks={'response': [self._response_callback]}),
+            http_client=httpx.Client(event_hooks={'response': [self.response_callback]}),
             api_key=self.api_key,
             organization=self.organization
         )
@@ -99,7 +97,6 @@ class AzureAPIConfiguration(APIConfiguration):
             base_url: str = None,
             api_version: str = '2023-05-15',
             deployment_id: str = 'gpt-3.5-turbo',
-            response_callback: callable = lambda response: None,
             api_base: str = None
     ):
         """
@@ -110,7 +107,6 @@ class AzureAPIConfiguration(APIConfiguration):
             base_url: The Azure API base URL.
             api_version: The Azure API version.
             deployment_id: The model deployment ID.
-            response_callback: A callback which is called when a response is received from the Azure API.
             api_base: (DEPRECATED) The Azure API base.
 
         """
@@ -129,7 +125,7 @@ class AzureAPIConfiguration(APIConfiguration):
 
         self.deployment_id = deployment_id
 
-        self._response_callback = response_callback
+        self.response_callback = lambda response: None
 
     def __call__(self):
         """
@@ -148,7 +144,7 @@ class AzureAPIConfiguration(APIConfiguration):
             default_headers={
                 'api-key': self.api_key
             },
-            http_client=httpx.Client(event_hooks={'response': [self._response_callback]}),
+            http_client=httpx.Client(event_hooks={'response': [self.response_callback]}),
         )
 
     def get_base_api_kwargs(self):
@@ -172,7 +168,6 @@ class AzureActiveDirectoryConfiguration:
             base_url: str,
             api_version: str = '2023-05-15',
             deployment_id: str = 'gpt-3.5-turbo',
-            response_callback: callable = lambda response: None,
             api_base: str = None
     ):
         """
@@ -185,7 +180,6 @@ class AzureActiveDirectoryConfiguration:
             base_url: The Azure Active Directory API base.
             api_version: The API version. https://learn.microsoft.com/en-us/azure/ai-services/openai/reference
             deployment_id: The model deployment ID
-            response_callback: A callback which is called when a response is received from the Azure Active Directory API.
             api_base: (DEPRECATED) The Azure Active Directory API base.
 
         """
@@ -202,7 +196,7 @@ class AzureActiveDirectoryConfiguration:
         self.api_version = api_version
         self.deployment_id = deployment_id
 
-        self._response_callback = response_callback
+        self.response_callback = lambda response: None
 
     def __call__(self):
         """
@@ -220,7 +214,7 @@ class AzureActiveDirectoryConfiguration:
         self.client = OpenAI(
             api_key=token.token,
             base_url=self.base_url,
-            http_client=httpx.Client(event_hooks={'response': [self._response_callback]}),
+            http_client=httpx.Client(event_hooks={'response': [self.response_callback]}),
             default_query={
                 'api-version': self.api_version
             }

--- a/phasellm/configurations.py
+++ b/phasellm/configurations.py
@@ -6,6 +6,8 @@ from openai import OpenAI
 
 from abc import ABC, abstractmethod
 
+from phasellm.utils import coerce_azure_base_url
+
 from azure.identity import DefaultAzureCredential
 
 
@@ -118,10 +120,12 @@ class AzureAPIConfiguration(APIConfiguration):
             warn('The api_base argument is deprecated. Use base_url instead.', DeprecationWarning)
 
         self.api_key = api_key
-        self.base_url = base_url
         self.api_version = api_version
+
+        self.base_url = base_url
         if api_base:
             self.base_url = api_base
+        self.base_url = coerce_azure_base_url(self.base_url)
 
         self.deployment_id = deployment_id
 
@@ -193,6 +197,7 @@ class AzureActiveDirectoryConfiguration:
         self.base_url = base_url
         if api_base:
             self.base_url = api_base
+        self.base_url = coerce_azure_base_url(self.base_url)
 
         self.api_version = api_version
         self.deployment_id = deployment_id

--- a/phasellm/llms.py
+++ b/phasellm/llms.py
@@ -760,7 +760,7 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
             **kwargs
         )
 
-        if api_config and (apikey or model):
+        if api_config and apikey:
             warn("api_config takes precedence over apikey and model arguments.")
 
         if apikey:
@@ -956,7 +956,7 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
         """
         super().__init__(temperature=temperature, **kwargs)
 
-        if api_config and (apikey or model):
+        if api_config and apikey:
             warn("api_config takes precedence over apikey and model arguments.")
 
         if apikey:

--- a/phasellm/llms.py
+++ b/phasellm/llms.py
@@ -725,7 +725,7 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
                 >>> llm = StreamingOpenAIGPTWrapper(api_config=AzureAPIConfiguration(
                 ...     api_key="azure_api_key",
                 ...     api_base='https://{your-resource-name}.openai.azure.com/openai/deployments/{your-deployment-id}',
-                ...     api_version='2023-08-01-preview',
+                ...     api_version='2023-05-15',
                 ...     deployment_id='your-deployment-id'
                 ... ))
                 >>> llm.text_completion(prompt="Hello, my name is")
@@ -735,7 +735,7 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
                 >>> from phasellm.configurations import AzureActiveDirectoryConfiguration
                 >>> llm = StreamingOpenAIGPTWrapper(api_config=AzureActiveDirectoryConfiguration(
                 ...     api_base='https://{your-resource-name}.openai.azure.com/openai/deployments/{your-deployment-id}',
-                ...     api_version='2023-08-01-preview',
+                ...     api_version='2023-05-15',
                 ...     deployment_id='your-deployment-id'
                 ... ))
                 >>> llm.text_completion(prompt="Hello, my name is")

--- a/phasellm/llms.py
+++ b/phasellm/llms.py
@@ -4,6 +4,8 @@ Abstract classes and wrappers for LLMs, chatbots, and prompts.
 import re
 import time
 import json
+
+import httpx
 import requests
 
 # Typing imports
@@ -22,7 +24,6 @@ from datetime import datetime
 from sseclient import SSEClient
 
 # Imports for external APIs
-import openai
 import cohere
 
 # Precompiled regex for variables.
@@ -205,6 +206,8 @@ class LanguageModelWrapper(ABC):
         "You are speaking to the 'user' below and will respond at the end, where it says 'assistant'.\n"
     )
 
+    _last_response_header: Optional[dict] = None
+
     def __init__(self, temperature: Optional[float] = None, **kwargs: Any):
         """
         Abstract Class for interacting with large language models.
@@ -220,8 +223,33 @@ class LanguageModelWrapper(ABC):
     def __repr__(self):
         pass
 
+    @property
+    def last_response_header(self) -> Optional[dict]:
+        """
+        Returns the last response header from the LLM API.
+
+        Returns:
+            A dictionary containing the last response header.
+        """
+        return self._last_response_header
+
+    @last_response_header.setter
+    def last_response_header(self, header: dict) -> None:
+        """
+        Sets the last_response_header property.
+
+        Returns:
+
+        """
+        self._last_response_header = header
+
     @abstractmethod
-    def complete_chat(self, messages: List[Message], append_role: Optional[str] = None) -> Union[str, Generator]:
+    def complete_chat(
+            self,
+            messages: List[Message],
+            append_role: Optional[str] = None,
+            prepend_role: Optional[str] = None
+    ) -> Union[str, Generator]:
         """
         Takes an array of messages in the form {"role": <str>, "content":<str>} and generate a response.
 
@@ -230,6 +258,7 @@ class LanguageModelWrapper(ABC):
         Args:
             messages: The messages to generate a response from.
             append_role: The role to append to the end of the prompt.
+            prepend_role: The role to prepend to the beginning of the prompt.
 
         Returns:
             The chat completion string or generator, depending on if the class is implemented as a streaming language
@@ -256,6 +285,7 @@ class LanguageModelWrapper(ABC):
     def prep_prompt_from_messages(
             self,
             messages: List[Message] = None,
+            prepend_role: Optional[str] = None,
             append_role: Optional[str] = None,
             include_preamble: Optional[bool] = False
     ) -> str:
@@ -264,6 +294,7 @@ class LanguageModelWrapper(ABC):
 
         Args:
             messages: The messages to prepare the prompt from.
+            prepend_role: The role to prepend to the beginning of the prompt.
             append_role: The role to append to the end of the prompt.
             include_preamble: Whether to include the chat completion preamble.
 
@@ -274,16 +305,45 @@ class LanguageModelWrapper(ABC):
         # Convert the messages to a prompt.
         prompt_text = _clean_messages_to_prompt(messages)
 
+        # Prepend the role, if provided.
+        if prepend_role:
+            prompt_text = f"\n\n{prepend_role}: {prompt_text}"
+
         # Add the preamble, if requested.
         if include_preamble:
             prompt_text = self.chat_completion_preamble + prompt_text
 
         # Append the role, if provided.
-        if append_role is not None and len(append_role) > 0:
-            prompt_text += f"\n{append_role}:"
+        if append_role:
+            prompt_text = f"{prompt_text}\n\n{append_role}:"
 
         # Remove whitespace from before and after prompt.
         return prompt_text.strip()
+
+    @staticmethod
+    def prep_prompt(prompt: str, prepend_role: Optional[str] = None, append_role: Optional[str] = None) -> str:
+        """
+        Prepares the prompt for an LLM API call.
+
+        Args:
+            prompt: The prompt to prepare.
+            prepend_role: The role to prepend to the beginning of the prompt.
+            append_role: The role to append to the end of the prompt.
+
+        Returns:
+            The prepared prompt.
+
+        """
+        # Prepend the role, if provided.
+        if prepend_role:
+            prompt = f"{prepend_role}: {prompt}"
+
+        # Append the role, if provided.
+        if append_role:
+            prompt = f"{prompt}\n\n{append_role}:"
+
+        # Remove whitespace from before and after prompt.
+        return prompt.strip()
 
     def _prep_common_kwargs(self, api_config: Optional[OPENAI_API_CONFIG] = None):
         """
@@ -481,19 +541,24 @@ class HuggingFaceInferenceWrapper(LanguageModelWrapper):
         if self.temperature is not None:
             payload["temperature"] = self.temperature
 
-        response = requests.post(self.model_url, headers=headers, json=payload).json()
+        response = requests.post(self.model_url, headers=headers, json=payload)
+
+        self.last_response_header = response.headers
+
+        response_json = response.json()
         return _remove_prompt_from_completion(
             prompt=prompt,
-            completion=response[0]['generated_text']
+            completion=response_json[0]['generated_text']
         )
 
-    def complete_chat(self, messages: List[Message], append_role: str = None) -> str:
+    def complete_chat(self, messages: List[Message], append_role: str = None, prepend_role: str = None) -> str:
         """
         Mimics a chat scenario via a list of {"role": <str>, "content":<str>} objects.
 
         Args:
             messages: The messages to generate a chat completion from.
             append_role: The role to append to the end of the prompt.
+            prepend_role: The role to prepend to the beginning of the prompt.
 
         Returns:
             The chat completion.
@@ -502,6 +567,7 @@ class HuggingFaceInferenceWrapper(LanguageModelWrapper):
 
         prompt = self.prep_prompt_from_messages(
             messages=messages,
+            prepend_role=prepend_role,
             append_role=append_role,
             include_preamble=True
         )
@@ -567,19 +633,24 @@ class BloomWrapper(LanguageModelWrapper):
         if self.temperature is not None:
             payload["temperature"] = self.temperature
 
-        response = requests.post(self.API_URL, headers=headers, json=payload).json()
+        response = requests.post(self.API_URL, headers=headers, json=payload)
+
+        self.last_response_header = response.headers
+
+        response_json = response.json()
         return _remove_prompt_from_completion(
             prompt=prompt,
-            completion=response[0]['generated_text']
+            completion=response_json[0]['generated_text']
         )
 
-    def complete_chat(self, messages: List[Message], append_role: str = None) -> str:
+    def complete_chat(self, messages: List[Message], append_role: str = None, prepend_role: str = None) -> str:
         """
         Mimics a chat scenario with BLOOM, via a list of {"role": <str>, "content":<str>} objects.
 
         Args:
             messages: The messages to generate a chat completion from.
             append_role: The role to append to the end of the prompt.
+            prepend_role: The role to prepend to the beginning of the prompt.
 
         Returns:
             The chat completion.
@@ -588,6 +659,7 @@ class BloomWrapper(LanguageModelWrapper):
 
         prompt = self.prep_prompt_from_messages(
             messages=messages,
+            prepend_role=prepend_role,
             append_role=append_role,
             include_preamble=True
         )
@@ -692,7 +764,11 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
             warn("api_config takes precedence over apikey and model arguments.")
 
         if apikey:
-            self.api_config = OpenAIConfiguration(api_key=apikey, model=model)
+            self.api_config = OpenAIConfiguration(
+                api_key=apikey,
+                model=model,
+                response_callback=self._set_last_response_header
+            )
         if api_config:
             self.api_config = api_config
 
@@ -705,7 +781,7 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
     def __repr__(self):
         return f"StreamingOpenAIGPTWrapper(model={self.api_config.model})"
 
-    def _yield_response(self, response: dict) -> Generator:
+    def _yield_response(self, response) -> Generator:
         """
         Yields the response content. Can handle multiple API versions.
 
@@ -718,18 +794,20 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
         """
         for chunk in response:
             text = None
-            if "text" in chunk["choices"][0]:
-                text = chunk["choices"][0]["text"]
-            elif "delta" in chunk["choices"][0] and "text" in chunk["choices"][0]["delta"]:
-                text = chunk["choices"][0]["delta"]["text"]
-            elif "delta" in chunk["choices"][0] and "content" in chunk["choices"][0]["delta"]:
-                text = chunk["choices"][0]["delta"]["content"]
+            if not chunk.choices:
+                text = ''
+            elif hasattr(chunk.choices[0], 'text'):
+                text = chunk.choices[0].text
+            elif hasattr(chunk.choices[0], 'delta') and hasattr(chunk.choices[0].delta, 'text'):
+                text = chunk.choices[0].delta.text
+            elif hasattr(chunk.choices[0], 'delta') and hasattr(chunk.choices[0].delta, 'content'):
+                text = chunk.choices[0].delta.content
             if text:
                 yield _conditional_format_sse_response(content=text, format_sse=self.format_sse)
         if self.format_sse and self.append_stop_token:
             yield _format_sse(content=self.stop_token)
 
-    def complete_chat(self, messages: List[Message], append_role: str = None) -> Generator:
+    def complete_chat(self, messages: List[Message], append_role: str = None, prepend_role: str = None) -> Generator:
         """
         Completes chat with OpenAI. If using GPT 3.5 or 4, will simply send the list of {"role": <str>, "content":<str>}
         objects to the API.
@@ -741,6 +819,7 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
         Args:
             messages: The messages to generate a chat completion from.
             append_role: The role to append to the end of the prompt.
+            prepend_role: The role to prepend to the beginning of the prompt.
 
         Returns:
             The chat completion generator.
@@ -752,17 +831,18 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
 
         if ('gpt-4' in self.api_config.model) or ('gpt-3.5' in self.api_config.model):
             kwargs["messages"] = messages
-            response = openai.ChatCompletion.create(**kwargs)
+            response = self.api_config.client.chat.completions.create(**kwargs)
             yield from self._yield_response(response)
         else:
             prompt_text = self.prep_prompt_from_messages(
                 messages=messages,
+                prepend_role=prepend_role,
                 append_role=append_role,
                 include_preamble=False
             )
             kwargs["prompt"] = prompt_text
             kwargs["stop"] = _get_stop_sequences_from_messages(messages)
-            response = openai.Completion.create(**kwargs)
+            response = self.api_config.client.completions.create(**kwargs)
             yield from self._yield_response(response)
 
     # TODO Consider error handling for chat models.
@@ -791,9 +871,22 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
         if stop_sequences:
             kwargs["stop"] = stop_sequences
 
-        response = openai.Completion.create(**kwargs)
+        response = self.api_config.client.completions.create(**kwargs)
 
         yield from self._yield_response(response)
+
+    def _set_last_response_header(self, response: httpx.Response) -> None:
+        """
+        Sets the last response header.
+
+        Args:
+            response: The response to set the last response header from.
+
+        Returns:
+            None
+
+        """
+        self.last_response_header = response.headers
 
 
 class OpenAIGPTWrapper(LanguageModelWrapper):
@@ -867,7 +960,11 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
             warn("api_config takes precedence over apikey and model arguments.")
 
         if apikey:
-            self.api_config = OpenAIConfiguration(api_key=apikey, model=model)
+            self.api_config = OpenAIConfiguration(
+                api_key=apikey,
+                model=model,
+                response_callback=self._set_last_response_header
+            )
         if api_config:
             self.api_config = api_config
 
@@ -880,7 +977,7 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
     def __repr__(self):
         return f"OpenAIGPTWrapper(model={self.api_config.model})"
 
-    def complete_chat(self, messages: List[Message], append_role: str = None) -> str:
+    def complete_chat(self, messages: List[Message], append_role: str = None, prepend_role: str = None) -> str:
         """
         Completes chat with OpenAI. If using GPT 3.5 or 4, will simply send the list of {"role": <str>, "content":<str>}
         objects to the API.
@@ -890,6 +987,7 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
         Args:
             messages: The messages to generate a chat completion from.
             append_role: The role to append to the end of the prompt.
+            prepend_role: The role to prepend to the beginning of the prompt.
 
         Returns:
             The chat completion.
@@ -899,17 +997,18 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
 
         if ('gpt-4' in self.api_config.model) or ('gpt-3.5' in self.api_config.model):
             kwargs["messages"] = messages
-            response = openai.ChatCompletion.create(**kwargs)
-            return response['choices'][0]['message']['content']
+            response = self.api_config.client.chat.completions.create(**kwargs)
+            return response.choices[0].message.content
         else:
             prompt_text = self.prep_prompt_from_messages(
                 messages=messages,
+                prepend_role=prepend_role,
                 append_role=append_role,
                 include_preamble=False
             )
             kwargs["prompt"] = prompt_text
-            response = openai.Completion.create(**kwargs)
-            return response['choices'][0]['text']
+            response = self.api_config.client.completions.create(**kwargs)
+            return response.choices[0].text
 
     # TODO Consider error handling for chat models.
     def text_completion(self, prompt: str, stop_sequences: List[str] = None) -> str:
@@ -927,14 +1026,27 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
 
         kwargs = self._prep_common_kwargs(self.api_config)
 
-        kwargs['prompt'] = prompt
+        kwargs['prompt'] = self.prep_prompt(prompt=prompt)
 
         if stop_sequences:
             kwargs["stop"] = stop_sequences
 
-        response = openai.Completion.create(**kwargs)
+        response = self.api_config.client.completions.create(**kwargs)
 
-        return response['choices'][0]['text']
+        return response.choices[0].text
+
+    def _set_last_response_header(self, response: httpx.Response) -> None:
+        """
+        Sets the last response header.
+
+        Args:
+            response: The response to set the last response header from.
+
+        Returns:
+            None
+
+        """
+        self.last_response_header = response.headers
 
 
 class StreamingClaudeWrapper(StreamingLanguageModelWrapper):
@@ -998,7 +1110,8 @@ class StreamingClaudeWrapper(StreamingLanguageModelWrapper):
         # https://docs.anthropic.com/claude/reference/complete_post
         headers = {
             "X-API-Key": self.apikey,
-            "Accept": "text/event-stream"
+            "Accept": "text/event-stream",
+            "anthropic-version": self.anthropic_version
         }
 
         kwargs = self._prep_common_kwargs()
@@ -1013,13 +1126,21 @@ class StreamingClaudeWrapper(StreamingLanguageModelWrapper):
         }
 
         resp = requests.post(self.API_URL, headers=headers, json=kwargs, stream=True)
+
+        self.last_response_header = resp.headers
+
         client = SSEClient(resp)
 
         strip_index = 0
         for event in client.events():
-            if event.data != "[DONE]":
+            if event.data and event.data != "[DONE]":
                 # Load the data as JSON
-                completion = json.loads(event.data)["completion"]
+                data = json.loads(event.data)
+
+                # Extract the completion if it is present.
+                completion = ''
+                if "completion" in data:
+                    completion = data["completion"]
 
                 # Anthropic's old API returns completions inclusive of previous chunks, so we need to strip them out.
                 if self.anthropic_version == "2023-01-01":
@@ -1031,22 +1152,35 @@ class StreamingClaudeWrapper(StreamingLanguageModelWrapper):
         if self.format_sse and self.append_stop_token:
             yield _format_sse(content=self.stop_token)
 
-    def complete_chat(self, messages: List[Message], append_role: str = "Assistant:") -> Generator:
+    def complete_chat(
+            self,
+            messages: List[Message],
+            append_role: str = "Assistant",
+            prepend_role: str = "Human"
+    ) -> Generator:
         """
-        Completes chat with Claude. Since Claude doesn't support a chat interface via API, we mimic the chat via the a
+        Completes chat with Claude. Since Claude doesn't support a chat interface via API, we mimic the chat via a
         prompt.
 
         Args:
             messages: The messages to generate a chat completion from.
             append_role: The role to append to the end of the prompt. Defaults to "Assistant:".
+            prepend_role: The role to prepend to the beginning of the prompt. Defaults to "Human:".
 
         Returns:
             The chat completion generator.
 
         """
+        if prepend_role != "Human":
+            warn("ClaudeWrapper only supports Human as the prepend_role. Ignoring.")
+            prepend_role = "Human"
+        if append_role != "Assistant":
+            warn("ClaudeWrapper only supports Assistant as the append_role. Ignoring.")
+            append_role = "Assistant"
 
         prompt_text = self.prep_prompt_from_messages(
             messages=messages,
+            prepend_role=prepend_role,
             append_role=append_role,
             include_preamble=False
         )
@@ -1073,6 +1207,8 @@ class StreamingClaudeWrapper(StreamingLanguageModelWrapper):
 
         if stop_sequences is None:
             stop_sequences = []
+
+        prompt = self.prep_prompt(prompt=prompt, prepend_role="Human", append_role="Assistant")
 
         return self._call_model(
             prompt=prompt,
@@ -1145,24 +1281,39 @@ class ClaudeWrapper(LanguageModelWrapper):
 
         resp = requests.post("https://api.anthropic.com/v1/complete", headers=headers, json=kwargs)
 
+        self.last_response_header = resp.headers
+
         return json.loads(resp.text)["completion"].strip()
 
-    def complete_chat(self, messages: List[Message], append_role: str = "Assistant:") -> str:
+    def complete_chat(
+            self,
+            messages: List[Message],
+            append_role: str = "Assistant",
+            prepend_role: str = "Human"
+    ) -> str:
         """
-        Completes chat with Claude. Since Claude doesn't support a chat interface via API, we mimic the chat via the a
+        Completes chat with Claude. Since Claude doesn't support a chat interface via API, we mimic the chat via a
         prompt.
 
         Args:
             messages: The messages to generate a chat completion from.
             append_role: The role to append to the end of the prompt. Defaults to "Assistant:".
+            prepend_role: The role to prepend to the beginning of the prompt. Defaults to "Human:".
 
         Returns:
             The chat completion.
 
         """
+        if prepend_role != "Human":
+            warn("ClaudeWrapper only supports Human as the prepend_role. Ignoring.")
+            prepend_role = "Human"
+        if append_role != "Assistant":
+            warn("ClaudeWrapper only supports Assistant as the append_role. Ignoring.")
+            append_role = "Assistant"
 
         prompt_text = self.prep_prompt_from_messages(
             messages=messages,
+            prepend_role=prepend_role,
             append_role=append_role,
             include_preamble=False
         )
@@ -1184,6 +1335,8 @@ class ClaudeWrapper(LanguageModelWrapper):
 
         if stop_sequences is None:
             stop_sequences = []
+
+        prompt = self.prep_prompt(prompt=prompt, prepend_role="Human", append_role="Assistant")
 
         return self._call_model(prompt, stop_sequences)
 
@@ -1239,7 +1392,13 @@ class GPT2Wrapper(LanguageModelWrapper):
 
         return _remove_prompt_from_completion(prompt, res[0]['generated_text'])
 
-    def complete_chat(self, messages: List[Message], append_role: str = None, max_length: int = 300) -> str:
+    def complete_chat(
+            self,
+            messages: List[Message],
+            append_role: str = None,
+            max_length: int = 300,
+            prepend_role: str = None
+    ) -> str:
         """
         Mimics a chat scenario via a list of {"role": <str>, "content":<str>} objects.
 
@@ -1247,6 +1406,7 @@ class GPT2Wrapper(LanguageModelWrapper):
             messages: The messages to generate a chat completion from.
             append_role: The role to append to the end of the prompt. Defaults to None.
             max_length: The maximum length of the completion. Defaults to 300.
+            prepend_role: The role to prepend to the beginning of the prompt. Defaults to None.
 
         Returns:
             The chat completion.
@@ -1255,6 +1415,7 @@ class GPT2Wrapper(LanguageModelWrapper):
 
         prompt = self.prep_prompt_from_messages(
             messages=messages,
+            prepend_role=prepend_role,
             append_role=append_role,
             include_preamble=True
         )
@@ -1272,6 +1433,8 @@ class GPT2Wrapper(LanguageModelWrapper):
             The text completion.
 
         """
+        prompt = self.prep_prompt(prompt=prompt)
+
         return self._call_model(prompt=prompt, max_length=max_length)
 
 
@@ -1329,13 +1492,14 @@ class DollyWrapper(LanguageModelWrapper):
 
         return _remove_prompt_from_completion(prompt, res[0]['generated_text'])
 
-    def complete_chat(self, messages: List[Message], append_role: str = None) -> str:
+    def complete_chat(self, messages: List[Message], append_role: str = None, prepend_role: str = None) -> str:
         """
         Mimics a chat scenario via a list of {"role": <str>, "content":<str>} objects.
 
         Args:
             messages: The messages to generate a chat completion from.
             append_role: The role to append to the end of the prompt. Defaults to None.
+            prepend_role: The role to prepend to the beginning of the prompt. Defaults to None.
 
         Returns:
             The chat completion.
@@ -1344,6 +1508,7 @@ class DollyWrapper(LanguageModelWrapper):
 
         prompt = self.prep_prompt_from_messages(
             messages=messages,
+            prepend_role=prepend_role,
             append_role=append_role,
             include_preamble=True
         )
@@ -1360,6 +1525,8 @@ class DollyWrapper(LanguageModelWrapper):
             The text completion.
 
         """
+        prompt = self.prep_prompt(prompt=prompt)
+
         return self._call_model(prompt=prompt)
 
 
@@ -1409,13 +1576,14 @@ class CohereWrapper(LanguageModelWrapper):
 
         return response.generations[0].text
 
-    def complete_chat(self, messages: List[Message], append_role: str = None) -> str:
+    def complete_chat(self, messages: List[Message], append_role: str = None, prepend_role: str = None) -> str:
         """
         Mimics a chat scenario via a list of {"role": <str>, "content":<str>} objects.
 
         Args:
             messages: The messages to generate a chat completion from.
             append_role: The role to append to the end of the prompt. Defaults to None.
+            prepend_role: The role to prepend to the beginning of the prompt. Defaults to None.
 
         Returns:
             The chat completion.
@@ -1424,6 +1592,7 @@ class CohereWrapper(LanguageModelWrapper):
 
         prompt_text = self.prep_prompt_from_messages(
             messages=messages,
+            prepend_role=prepend_role,
             append_role=append_role,
             include_preamble=False
         )
@@ -1451,6 +1620,8 @@ class CohereWrapper(LanguageModelWrapper):
 
         if stop_sequences is None:
             stop_sequences = []
+
+        prompt = self.prep_prompt(prompt=prompt)
 
         return self._call_model(prompt=prompt, stop_sequences=stop_sequences)
 
@@ -1576,7 +1747,7 @@ class ChatBot:
             m_copy = {"role": m["role"], "content": m["content"]}
             clean_messages.append(m_copy)
 
-        response = self.llm.complete_chat(clean_messages, append_role='assistant')
+        response = self.llm.complete_chat(clean_messages, append_role='Assistant')
 
         if isinstance(response, Generator):
             return self._streaming_response(response=response, start_time=start_time)

--- a/phasellm/llms.py
+++ b/phasellm/llms.py
@@ -766,14 +766,15 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
         if apikey:
             self.api_config = OpenAIConfiguration(
                 api_key=apikey,
-                model=model,
-                response_callback=self._set_last_response_header
+                model=model
             )
         if api_config:
             self.api_config = api_config
 
         if not hasattr(self, 'api_config'):
             raise Exception('Must pass apikey or api_config. If using kwargs, check capitalization.')
+
+        self.api_config.response_callback = self._set_last_response_header
 
         # Activate the configuration
         self.api_config()
@@ -962,14 +963,15 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
         if apikey:
             self.api_config = OpenAIConfiguration(
                 api_key=apikey,
-                model=model,
-                response_callback=self._set_last_response_header
+                model=model
             )
         if api_config:
             self.api_config = api_config
 
         if not hasattr(self, 'api_config'):
             raise Exception('Must pass apikey or api_config. If using kwargs, check capitalization.')
+
+        self.api_config.response_callback = self._set_last_response_header
 
         # Activate the configuration
         self.api_config()

--- a/phasellm/llms.py
+++ b/phasellm/llms.py
@@ -715,7 +715,7 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
             Use OpenAI's API with api_config:
                 >>> from phasellm.configurations import OpenAIConfiguration
                 >>> llm = StreamingOpenAIGPTWrapper(api_config=OpenAIConfiguration(
-                ...     apikey="my-api-key",
+                ...     api_key="my-api-key",
                 ...     organization="my-org",
                 ...     model="gpt-3.5-turbo"
                 ... ))
@@ -723,9 +723,9 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
             Use Azure's API:
                 >>> from phasellm.configurations import AzureAPIConfiguration
                 >>> llm = StreamingOpenAIGPTWrapper(api_config=AzureAPIConfiguration(
-                ...     apikey="azure_api_key",
-                ...     api_base='https://{your-resource-name}.openai.azure.com/',
-                ...     api_version='2023-05-15',
+                ...     api_key="azure_api_key",
+                ...     api_base='https://{your-resource-name}.openai.azure.com/openai/deployments/{your-deployment-id}',
+                ...     api_version='2023-08-01-preview',
                 ...     deployment_id='your-deployment-id'
                 ... ))
                 >>> llm.text_completion(prompt="Hello, my name is")
@@ -734,8 +734,8 @@ class StreamingOpenAIGPTWrapper(StreamingLanguageModelWrapper):
             Use Azure's API with Active Directory authentication:
                 >>> from phasellm.configurations import AzureActiveDirectoryConfiguration
                 >>> llm = StreamingOpenAIGPTWrapper(api_config=AzureActiveDirectoryConfiguration(
-                ...     api_base='https://{your-resource-name}.openai.azure.com/',
-                ...     api_version='2023-05-15',
+                ...     api_base='https://{your-resource-name}.openai.azure.com/openai/deployments/{your-deployment-id}',
+                ...     api_version='2023-08-01-preview',
                 ...     deployment_id='your-deployment-id'
                 ... ))
                 >>> llm.text_completion(prompt="Hello, my name is")
@@ -920,7 +920,7 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
             Use OpenAI's API with api_config:
                 >>> from phasellm.configurations import OpenAIConfiguration
                 >>> llm = OpenAIGPTWrapper(api_config=OpenAIConfiguration(
-                ...     apikey="my-api-key",
+                ...     api_key="my-api-key",
                 ...     organization="my-org",
                 ...     model="gpt-3.5-turbo"
                 ... ))
@@ -928,9 +928,9 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
             Use Azure's API:
                 >>> from phasellm.configurations import AzureAPIConfiguration
                 >>> llm = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
-                ...     apikey="azure_api_key",
-                ...     api_base='https://{your-resource-name}.openai.azure.com/',
-                ...     api_version='2023-05-15',
+                ...     api_key="azure_api_key",
+                ...     api_base='https://{your-resource-name}.openai.azure.com/openai/deployments/{your-deployment-id}',
+                ...     api_version='2023-08-01-preview',
                 ...     deployment_id='your-deployment-id'
                 ... ))
                 >>> llm.text_completion(prompt="Hello, my name is")
@@ -939,8 +939,8 @@ class OpenAIGPTWrapper(LanguageModelWrapper):
             Use Azure's API with Active Directory authentication:
                 >>> from phasellm.configurations import AzureActiveDirectoryConfiguration
                 >>> llm = OpenAIGPTWrapper(api_config=AzureActiveDirectoryConfiguration(
-                ...     api_base='https://{your-resource-name}.openai.azure.com/',
-                ...     api_version='2023-05-15',
+                ...     api_base='https://{your-resource-name}.openai.azure.com/openai/deployments/{your-deployment-id}',
+                ...     api_version='2023-08-01-preview',
                 ...     deployment_id='your-deployment-id'
                 ... ))
                 >>> llm.text_completion(prompt="Hello, my name is")

--- a/phasellm/utils.py
+++ b/phasellm/utils.py
@@ -1,0 +1,29 @@
+import re
+
+from warnings import warn
+
+
+def coerce_azure_base_url(url: str) -> str:
+    """
+    This function coerces the base URL to the proper format for the Azure OpenAI API. This is used for backwards
+    compatibility of base_url and api_base arguments.
+    Args:
+        url: The url to coerce.
+
+    Returns:
+        The coerced URL.
+
+    """
+    match = re.match(r'https:\/\/.*\.openai\.azure.com\/openai\/deployments\/.*', url)
+    if not match:
+        # Ensure proper format of the base URL.
+        res = re.search(r'https:\/\/.*\.openai\.azure.com(?!\/openai\/deployments\/)', url)
+        if res.group():
+            # see https://github.com/openai/openai-python/blob/v1/examples/azure.py
+            warn('The base_url argument must be in the format:'
+                 'https://{resource}.openai.azure.com/openai/deployments/{model}\n'
+                 'Attempting to coerce base_url to the proper format.')
+            url = f"{url[:res.end()]}/openai/deployments{url[res.end():]}"
+            warn(f'Coerced url to: {url}')
+            return url
+    return url

--- a/project_metadata.py
+++ b/project_metadata.py
@@ -2,7 +2,7 @@ NAME = "phasellm"
 
 AUTHOR = "Wojciech Gryc"
 
-VERSION = "0.0.17"
+VERSION = "0.0.18"
 
 DESCRIPTION = "Wrappers for common large language models (LLMs) with support for evaluation."
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask>=2.0.0
 requests>=2.24.0
-openai>=0.26.0
+httpx>=0.25.0
+openai==1.0.0b2
 cohere>=4.0.0
 transformers>=4.25.0
 accelerate>=0.16.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
     install_requires=[
         "Flask>=2.0.0",
         "requests>=2.24.0",
-        "openai>=0.26.0",
+        "httpx>=0.25.0",
+        "openai==1.0.0b2",
         "cohere>=4.0.0",
         "python-dotenv",
         "pandas>=2.0.0",

--- a/tests/e2e/agents/test_e2e_agents.py
+++ b/tests/e2e/agents/test_e2e_agents.py
@@ -202,7 +202,7 @@ class TestE2EWebpageAgent(TestCase):
             use_browser=False
         )
         self.assertTrue(
-            'Canadian journalism.Government says' in
+            "Government says law will apply to companies with 'significant bargaining power imbalance'" in
             text, f"Text does not contain expected string.\n{text}"
         )
 

--- a/tests/e2e/llms/test_e2e_llms.py
+++ b/tests/e2e/llms/test_e2e_llms.py
@@ -105,8 +105,8 @@ class E2ETestOpenAIGPTWrapper(TestCase):
     def test_complete_chat_azure(self):
         fixture = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
             api_key=azure_api_key,
-            api_base='https://val-gpt4.openai.azure.com/',
-            api_version='2023-05-15',
+            base_url=f'https://val-gpt4.openai.azure.com/openai/deployments/gpt-4',
+            api_version='2023-08-01-preview',
             deployment_id='gpt-4'
         ))
         test_complete_chat(self, fixture, verbose=False)
@@ -278,8 +278,8 @@ class E2ETestStreamingOpenAIGPTWrapper(TestCase):
         """
         fixture = StreamingOpenAIGPTWrapper(api_config=AzureAPIConfiguration(
             api_key=azure_api_key,
-            api_base='https://val-gpt4.openai.azure.com/',
-            api_version='2023-05-15',
+            base_url=f'https://val-gpt4.openai.azure.com/openai/deployments/gpt-4',
+            api_version='2023-08-01-preview',
             deployment_id='gpt-4'
         ))
 
@@ -529,8 +529,8 @@ class E2ETestChatBot(TestCase):
     def test_openai_gpt_chat_azure(self):
         llm = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
             api_key=azure_api_key,
-            api_base='https://val-gpt4.openai.azure.com/',
-            api_version='2023-05-15',
+            base_url=f'https://val-gpt4.openai.azure.com/openai/deployments/gpt-4',
+            api_version='2023-08-01-preview',
             deployment_id='gpt-4'
         ))
         fixture = ChatBot(llm)
@@ -674,8 +674,8 @@ class E2ETestStreamingChatBot(TestCase):
     def test_openai_gpt_streaming_chat_azure(self):
         llm = StreamingOpenAIGPTWrapper(api_config=AzureAPIConfiguration(
             api_key=azure_api_key,
-            api_base='https://val-gpt4.openai.azure.com/',
-            api_version='2023-05-15',
+            base_url=f'https://val-gpt4.openai.azure.com/openai/deployments/gpt-4',
+            api_version='2023-08-01-preview',
             deployment_id='gpt-4'
         ))
         fixture = ChatBot(llm)

--- a/tests/e2e/llms/test_e2e_llms.py
+++ b/tests/e2e/llms/test_e2e_llms.py
@@ -50,7 +50,7 @@ class E2ETestHuggingFaceInferenceWrapper(TestCase):
             hugging_face_api_key,
             model_url="https://api-inference.huggingface.co/models/bigscience/bloom"
         )
-        test_complete_chat(self, fixture, verbose=False)
+        test_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_complete_chat_kwargs(self):
         fixture = HuggingFaceInferenceWrapper(
@@ -59,14 +59,14 @@ class E2ETestHuggingFaceInferenceWrapper(TestCase):
             temperature=0.9,
             top_k=2
         )
-        test_complete_chat(self, fixture, verbose=False)
+        test_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_success(self):
         fixture = HuggingFaceInferenceWrapper(
             hugging_face_api_key,
             model_url="https://api-inference.huggingface.co/models/bigscience/bloom"
         )
-        test_text_completion_success(self, fixture, verbose=False)
+        test_text_completion_success(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_success_kwargs(self):
         fixture = HuggingFaceInferenceWrapper(
@@ -75,7 +75,7 @@ class E2ETestHuggingFaceInferenceWrapper(TestCase):
             top_k=0.9,
             model_url="https://api-inference.huggingface.co/models/bigscience/bloom"
         )
-        test_text_completion_success(self, fixture, verbose=False)
+        test_text_completion_success(self, fixture, check_last_response_header=True, verbose=False)
 
 
 class E2ETestBloomWrapper(TestCase):
@@ -86,11 +86,11 @@ class E2ETestBloomWrapper(TestCase):
 
     def test_complete_chat(self):
         fixture = BloomWrapper(hugging_face_api_key)
-        test_complete_chat(self, fixture, verbose=False)
+        test_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_success(self):
         fixture = BloomWrapper(hugging_face_api_key)
-        test_text_completion_success(self, fixture, verbose=False)
+        test_text_completion_success(self, fixture, check_last_response_header=True, verbose=False)
 
 
 class E2ETestOpenAIGPTWrapper(TestCase):
@@ -100,7 +100,7 @@ class E2ETestOpenAIGPTWrapper(TestCase):
 
     def test_complete_chat(self):
         fixture = OpenAIGPTWrapper(openai_api_key, model="gpt-3.5-turbo")
-        test_complete_chat(self, fixture, verbose=False)
+        test_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_complete_chat_azure(self):
         fixture = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
@@ -109,7 +109,7 @@ class E2ETestOpenAIGPTWrapper(TestCase):
             api_version='2023-05-15',
             deployment_id='gpt-4'
         ))
-        test_complete_chat(self, fixture, verbose=False)
+        test_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_complete_chat_azure_pre_openai_v1(self):
         fixture = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
@@ -118,19 +118,19 @@ class E2ETestOpenAIGPTWrapper(TestCase):
             api_version='2023-05-15',
             deployment_id='gpt-4'
         ))
-        test_complete_chat(self, fixture, verbose=False)
+        test_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_complete_chat_kwargs(self):
         fixture = OpenAIGPTWrapper(openai_api_key, model="gpt-3.5-turbo", temperature=0.9, frequency_penalty=2)
-        test_complete_chat(self, fixture, verbose=False)
+        test_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_success(self):
         fixture = OpenAIGPTWrapper(openai_api_key, model="text-davinci-003")
-        test_text_completion_success(self, fixture, verbose=False)
+        test_text_completion_success(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_success_kwargs(self):
         fixture = OpenAIGPTWrapper(openai_api_key, model="text-davinci-003", temperature=0.9, presence_penalty=2)
-        test_text_completion_success(self, fixture, verbose=False)
+        test_text_completion_success(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_failure(self):
         """
@@ -147,19 +147,19 @@ class E2ETestClaudeWrapper(TestCase):
 
     def test_complete_chat(self):
         fixture = ClaudeWrapper(anthropic_api_key, model="claude-v1")
-        test_complete_chat(self, fixture, verbose=False)
+        test_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_complete_chat_kwargs(self):
         fixture = ClaudeWrapper(anthropic_api_key, model="claude-v1", temperature=0.9, top_k=2)
-        test_complete_chat(self, fixture, verbose=False)
+        test_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_success(self):
         fixture = ClaudeWrapper(anthropic_api_key, model="claude-v1")
-        test_text_completion_success(self, fixture, verbose=False)
+        test_text_completion_success(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_success_kwargs(self):
         fixture = ClaudeWrapper(anthropic_api_key, model="claude-v1", temperature=0.9, top_k=2)
-        test_text_completion_success(self, fixture, verbose=False)
+        test_text_completion_success(self, fixture, check_last_response_header=True, verbose=False)
 
 
 class E2ETestGPT2Wrapper(TestCase):
@@ -279,7 +279,7 @@ class E2ETestStreamingOpenAIGPTWrapper(TestCase):
         """
         fixture = StreamingOpenAIGPTWrapper(openai_api_key, model="gpt-3.5-turbo")
 
-        test_streaming_complete_chat(self, fixture, verbose=False)
+        test_streaming_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_complete_chat_azure(self):
         """
@@ -292,7 +292,20 @@ class E2ETestStreamingOpenAIGPTWrapper(TestCase):
             deployment_id='gpt-4'
         ))
 
-        test_streaming_complete_chat(self, fixture, verbose=False)
+        test_streaming_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
+
+    def test_complete_chat_azure_pre_openai_v1(self):
+        """
+        Tests that the StreamingOpenAIGPTWrapper with azure configuration can be used to perform chat completion.
+        """
+        fixture = StreamingOpenAIGPTWrapper(api_config=AzureAPIConfiguration(
+            api_key=azure_api_key,
+            base_url=f'https://val-gpt4.openai.azure.com/gpt-4',
+            api_version='2023-05-15',
+            deployment_id='gpt-4'
+        ))
+
+        test_streaming_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_complete_chat_kwargs(self):
         """
@@ -302,7 +315,7 @@ class E2ETestStreamingOpenAIGPTWrapper(TestCase):
             openai_api_key, model="gpt-3.5-turbo", temperature=0.9, presence_penalty=0.9, frequency_penalty=0.9
         )
 
-        test_streaming_complete_chat(self, fixture, verbose=False)
+        test_streaming_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_complete_chat_sse(self):
         """
@@ -353,7 +366,7 @@ class E2ETestStreamingOpenAIGPTWrapper(TestCase):
         """
         fixture = StreamingOpenAIGPTWrapper(openai_api_key, model="text-davinci-003")
 
-        test_streaming_text_completion_success(self, fixture, verbose=False)
+        test_streaming_text_completion_success(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_success_kwargs(self):
         """
@@ -362,7 +375,7 @@ class E2ETestStreamingOpenAIGPTWrapper(TestCase):
         fixture = StreamingOpenAIGPTWrapper(openai_api_key, model="text-davinci-003", temperature=0.9,
                                             presence_penalty=2)
 
-        test_streaming_text_completion_success(self, fixture, verbose=False)
+        test_streaming_text_completion_success(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_failure(self):
         """
@@ -427,7 +440,7 @@ class E2ETestStreamingClaudeWrapper(TestCase):
         """
         fixture = StreamingClaudeWrapper(anthropic_api_key, model="claude-v1")
 
-        test_streaming_complete_chat(self, fixture, verbose=False)
+        test_streaming_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_complete_chat_kwargs(self):
         """
@@ -435,7 +448,7 @@ class E2ETestStreamingClaudeWrapper(TestCase):
         """
         fixture = StreamingClaudeWrapper(anthropic_api_key, model="claude-v1", temperature=0.9, top_k=2)
 
-        test_streaming_complete_chat(self, fixture, verbose=False)
+        test_streaming_complete_chat(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_complete_chat_sse(self):
         """
@@ -478,7 +491,7 @@ class E2ETestStreamingClaudeWrapper(TestCase):
         """
         fixture = StreamingClaudeWrapper(anthropic_api_key, model="claude-v1")
 
-        test_streaming_text_completion_success(self, fixture, verbose=False)
+        test_streaming_text_completion_success(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_kwargs(self):
         """
@@ -486,7 +499,7 @@ class E2ETestStreamingClaudeWrapper(TestCase):
         """
         fixture = StreamingClaudeWrapper(anthropic_api_key, model="claude-v1", temperature=0.9, top_k=2)
 
-        test_streaming_text_completion_success(self, fixture, verbose=False)
+        test_streaming_text_completion_success(self, fixture, check_last_response_header=True, verbose=False)
 
     def test_text_completion_sse(self):
         """
@@ -539,6 +552,17 @@ class E2ETestChatBot(TestCase):
         llm = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
             api_key=azure_api_key,
             base_url=f'https://val-gpt4.openai.azure.com/openai/deployments/gpt-4',
+            api_version='2023-05-15',
+            deployment_id='gpt-4'
+        ))
+        fixture = ChatBot(llm)
+
+        test_chatbot_chat(self, fixture)
+
+    def test_openai_gpt_chat_azure_pre_openai_v1(self):
+        llm = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
+            api_key=azure_api_key,
+            base_url=f'https://val-gpt4.openai.azure.com/gpt-4',
             api_version='2023-05-15',
             deployment_id='gpt-4'
         ))
@@ -684,6 +708,17 @@ class E2ETestStreamingChatBot(TestCase):
         llm = StreamingOpenAIGPTWrapper(api_config=AzureAPIConfiguration(
             api_key=azure_api_key,
             base_url=f'https://val-gpt4.openai.azure.com/openai/deployments/gpt-4',
+            api_version='2023-05-15',
+            deployment_id='gpt-4'
+        ))
+        fixture = ChatBot(llm)
+
+        test_streaming_chatbot_chat(self, fixture=fixture, chunk_time_seconds_threshold=0.5, verbose=False)
+
+    def test_openai_gpt_streaming_chat_azure_pre_openai_v1(self):
+        llm = StreamingOpenAIGPTWrapper(api_config=AzureAPIConfiguration(
+            api_key=azure_api_key,
+            base_url=f'https://val-gpt4.openai.azure.com/gpt-4',
             api_version='2023-05-15',
             deployment_id='gpt-4'
         ))

--- a/tests/e2e/llms/test_e2e_llms.py
+++ b/tests/e2e/llms/test_e2e_llms.py
@@ -106,7 +106,7 @@ class E2ETestOpenAIGPTWrapper(TestCase):
         fixture = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
             api_key=azure_api_key,
             base_url=f'https://val-gpt4.openai.azure.com/openai/deployments/gpt-4',
-            api_version='2023-08-01-preview',
+            api_version='2023-05-15',
             deployment_id='gpt-4'
         ))
         test_complete_chat(self, fixture, verbose=False)
@@ -279,7 +279,7 @@ class E2ETestStreamingOpenAIGPTWrapper(TestCase):
         fixture = StreamingOpenAIGPTWrapper(api_config=AzureAPIConfiguration(
             api_key=azure_api_key,
             base_url=f'https://val-gpt4.openai.azure.com/openai/deployments/gpt-4',
-            api_version='2023-08-01-preview',
+            api_version='2023-05-15',
             deployment_id='gpt-4'
         ))
 
@@ -530,7 +530,7 @@ class E2ETestChatBot(TestCase):
         llm = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
             api_key=azure_api_key,
             base_url=f'https://val-gpt4.openai.azure.com/openai/deployments/gpt-4',
-            api_version='2023-08-01-preview',
+            api_version='2023-05-15',
             deployment_id='gpt-4'
         ))
         fixture = ChatBot(llm)
@@ -675,7 +675,7 @@ class E2ETestStreamingChatBot(TestCase):
         llm = StreamingOpenAIGPTWrapper(api_config=AzureAPIConfiguration(
             api_key=azure_api_key,
             base_url=f'https://val-gpt4.openai.azure.com/openai/deployments/gpt-4',
-            api_version='2023-08-01-preview',
+            api_version='2023-05-15',
             deployment_id='gpt-4'
         ))
         fixture = ChatBot(llm)

--- a/tests/e2e/llms/test_e2e_llms.py
+++ b/tests/e2e/llms/test_e2e_llms.py
@@ -111,6 +111,15 @@ class E2ETestOpenAIGPTWrapper(TestCase):
         ))
         test_complete_chat(self, fixture, verbose=False)
 
+    def test_complete_chat_azure_pre_openai_v1(self):
+        fixture = OpenAIGPTWrapper(api_config=AzureAPIConfiguration(
+            api_key=azure_api_key,
+            base_url=f'https://val-gpt4.openai.azure.com/gpt-4',
+            api_version='2023-05-15',
+            deployment_id='gpt-4'
+        ))
+        test_complete_chat(self, fixture, verbose=False)
+
     def test_complete_chat_kwargs(self):
         fixture = OpenAIGPTWrapper(openai_api_key, model="gpt-3.5-turbo", temperature=0.9, frequency_penalty=2)
         test_complete_chat(self, fixture, verbose=False)

--- a/tests/e2e/llms/utils.py
+++ b/tests/e2e/llms/utils.py
@@ -14,10 +14,6 @@ from typing import Generator, List, Tuple
 from phasellm.llms import LanguageModelWrapper, StreamingLanguageModelWrapper, ChatBot
 
 
-def wrap_human_assistant(text: str) -> str:
-    return f'\n\nHuman: {text}\n\nAssistant:'
-
-
 def create_test_message_stack() -> List[dict]:
     m = [{'role': 'system', 'content': "You are a robot that adds 'YO!' to the end of every sentence."},
          {'role': 'user', 'content': 'Tell me about Poland.'}]
@@ -63,6 +59,22 @@ def common_text_assertions(tester: TestCase, response: str, verbose: bool = Fals
 
     if verbose:
         print(f"Chat: {response}")
+
+
+def common_last_response_header_assertion(
+        tester: TestCase,
+        fixture: LanguageModelWrapper,
+        verbose: bool = False
+) -> None:
+    """
+    Helper function for common last response header assertions.
+    """
+    tester.assertTrue(
+        len(fixture.last_response_header) > 0,
+        "Expecting last_response_headers to be set."
+    )
+    if verbose:
+        print(f"Last response headers: {fixture.last_response_header}")
 
 
 @dataclass
@@ -334,6 +346,7 @@ def common_chatbot_resend_assertions(
 def test_complete_chat(
         tester: TestCase,
         fixture: LanguageModelWrapper,
+        check_last_response_header: bool = False,
         verbose: bool = False
 ) -> None:
     messages = [{"role": "user", "content": "What should I eat for lunch today?"}]
@@ -341,16 +354,23 @@ def test_complete_chat(
 
     common_chat_assertions(tester=tester, response=response, verbose=verbose)
 
+    if check_last_response_header:
+        common_last_response_header_assertion(tester=tester, fixture=fixture, verbose=verbose)
+
 
 def test_text_completion_success(
         tester: TestCase,
         fixture: LanguageModelWrapper,
+        check_last_response_header: bool = False,
         verbose: bool = False
 ) -> None:
     prompt = "Three countries in North America are: "
     response = fixture.text_completion(prompt)
 
     common_text_assertions(tester=tester, response=response, verbose=verbose)
+
+    if check_last_response_header:
+        common_last_response_header_assertion(tester=tester, fixture=fixture, verbose=verbose)
 
 
 def test_text_completion_failure(
@@ -375,6 +395,7 @@ def test_text_completion_failure(
 def test_streaming_complete_chat(
         tester: TestCase,
         fixture: StreamingLanguageModelWrapper,
+        check_last_response_header: bool = False,
         verbose: bool = False
 ) -> None:
     """
@@ -386,6 +407,9 @@ def test_streaming_complete_chat(
     results: StreamingChatCompletionProbe = probe_streaming_chat_completion(generator)
 
     common_streaming_chat_assertions(tester=tester, probe=results, chunk_time_seconds_threshold=0.5, verbose=verbose)
+
+    if check_last_response_header:
+        common_last_response_header_assertion(tester=tester, fixture=fixture, verbose=verbose)
 
 
 def test_streaming_complete_chat_sse(
@@ -407,6 +431,7 @@ def test_streaming_complete_chat_sse(
 def test_streaming_text_completion_success(
         tester: TestCase,
         fixture: StreamingLanguageModelWrapper,
+        check_last_response_header: bool = False,
         verbose: bool = False
 ) -> None:
     prompt = "Three countries in North America are: "
@@ -415,6 +440,9 @@ def test_streaming_text_completion_success(
     result: StreamingTextCompletionProbe = probe_streaming_text_completion(generator)
 
     common_streaming_text_assertions(tester=tester, probe=result, verbose=verbose)
+
+    if check_last_response_header:
+        common_last_response_header_assertion(tester=tester, fixture=fixture, verbose=verbose)
 
 
 def test_streaming_text_completion_failure(


### PR DESCRIPTION
**Summary of Changes**

1) Implemented beta version of new OpenAI Python client (v1).
2) Added new last_response_header attribute to LanguageModelWrapper which keeps track of the last API call's headers. last_response_header is useful for APIs which provide API usage data such as rate limits (e.g. OpenAI).
3) While working on this ticket, I encountered API drift for the Anthropic API, which resulted in some bug fixes. Notably, the Anthropic API now enforces a 'Human:' prompt prefix and an 'Assistant:' prompt suffix.
4) Due to the aforementioned fix, prepend_role is now an option in complete_chat() in addition to the existing append_role parameter.